### PR TITLE
Starred Repositories

### DIFF
--- a/OctoKit.xcodeproj/project.pbxproj
+++ b/OctoKit.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		23B2678C1BDDD756003887E3 /* PublicKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23B267871BDDD756003887E3 /* PublicKey.swift */; };
 		23B2678D1BDDD756003887E3 /* Repositories.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23B267881BDDD756003887E3 /* Repositories.swift */; };
 		23B2678E1BDDD756003887E3 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23B267891BDDD756003887E3 /* User.swift */; };
+		E7EE59D81BDFEFB30012E3D2 /* Stars.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7EE59D71BDFEFB30012E3D2 /* Stars.swift */; };
+		E7EE59DA1BE10DA60012E3D2 /* StarsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7EE59D91BE10DA60012E3D2 /* StarsTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -76,6 +78,8 @@
 		23B267881BDDD756003887E3 /* Repositories.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Repositories.swift; sourceTree = "<group>"; };
 		23B267891BDDD756003887E3 /* User.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		23B2679C1BDDDBBE003887E3 /* Nocilla.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nocilla.framework; path = Carthage/Build/iOS/Nocilla.framework; sourceTree = "<group>"; };
+		E7EE59D71BDFEFB30012E3D2 /* Stars.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Stars.swift; sourceTree = "<group>"; };
+		E7EE59D91BE10DA60012E3D2 /* StarsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StarsTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -106,6 +110,7 @@
 				234F4BCB1BDDE3F900A58EF7 /* OctokitSwiftTests.swift */,
 				234F4BCC1BDDE3F900A58EF7 /* PublicKeyTests.swift */,
 				234F4BCD1BDDE3F900A58EF7 /* RepositoryTests.swift */,
+				E7EE59D91BE10DA60012E3D2 /* StarsTests.swift */,
 				234F4BCE1BDDE3F900A58EF7 /* TestHelper.swift */,
 				234F4BCF1BDDE3F900A58EF7 /* UserTests.swift */,
 				234F4BAD1BDDE31A00A58EF7 /* Info.plist */,
@@ -134,6 +139,7 @@
 				23B267871BDDD756003887E3 /* PublicKey.swift */,
 				23B267881BDDD756003887E3 /* Repositories.swift */,
 				23B267891BDDD756003887E3 /* User.swift */,
+				E7EE59D71BDFEFB30012E3D2 /* Stars.swift */,
 				239BE7CB1B8C47A100D2CE22 /* Supporting Files */,
 			);
 			path = OctoKit;
@@ -296,6 +302,7 @@
 				234F4BD51BDDE3F900A58EF7 /* TestHelper.swift in Sources */,
 				234F4BD01BDDE3F900A58EF7 /* ConfigurationTests.swift in Sources */,
 				234F4BD21BDDE3F900A58EF7 /* OctokitSwiftTests.swift in Sources */,
+				E7EE59DA1BE10DA60012E3D2 /* StarsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -304,6 +311,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				23B2678A1BDDD756003887E3 /* Configuration.swift in Sources */,
+				E7EE59D81BDFEFB30012E3D2 /* Stars.swift in Sources */,
 				23B2678D1BDDD756003887E3 /* Repositories.swift in Sources */,
 				23B2678C1BDDD756003887E3 /* PublicKey.swift in Sources */,
 				23B2678E1BDDD756003887E3 /* User.swift in Sources */,

--- a/OctoKit/Stars.swift
+++ b/OctoKit/Stars.swift
@@ -1,0 +1,71 @@
+//
+//  Stars.swift
+//  OctoKit
+//
+//  Created by Nate West on 10/27/15.
+//  Copyright © 2015 nerdish by nature. All rights reserved.
+//
+
+import Foundation
+
+public extension Octokit {
+    public func stars(name: String, completion: (response: Response<[Repository]>) -> Void) {
+        loadJSON(StarsRouter.ReadStars(name, self), expectedResultType: [[String: AnyObject]].self) { json, error in
+            if let error = error {
+                completion(response: Response.Failure(error))
+            } else {
+                if let json = json {
+                    let parsedStars = json.map { Repository($0) }
+                    completion(response: Response.Success(parsedStars))
+                }
+            }
+        }
+    }
+
+    public func myStars(completion: (response: Response<[Repository]>) -> Void) {
+        loadJSON(StarsRouter.ReadAuthenticatedStars(self), expectedResultType: [[String: AnyObject]].self) { json, error in
+            if let error = error {
+                completion(response: Response.Failure(error))
+            } else {
+                if let json = json {
+                    let parsedStars = json.map { Repository($0) }
+                    completion(response: Response.Success(parsedStars))
+                }
+            }
+        }
+    }
+}
+
+public enum StarsRouter: Router {
+    case ReadAuthenticatedStars(Octokit)
+    case ReadStars(String, Octokit)
+    public var method: HTTPMethod {
+        return .GET
+    }
+
+    public var encoding: HTTPEncoding {
+        return .URL
+    }
+
+    public var path: String {
+        switch self {
+        case .ReadAuthenticatedStars:
+            return "user/starred"
+        case .ReadStars(let username, _):
+            return "users/\(username)/starred"
+        }
+    }
+
+    public var params: [String: String] {
+        return [:]
+    }
+
+    public var URLRequest: NSURLRequest? {
+        switch self {
+        case .ReadAuthenticatedStars(let kit):
+            return kit.request(self)
+        case .ReadStars(_, let kit):
+            return kit.request(self)
+        }
+    }
+}

--- a/OctoKit/Stars.swift
+++ b/OctoKit/Stars.swift
@@ -1,11 +1,3 @@
-//
-//  Stars.swift
-//  OctoKit
-//
-//  Created by Nate West on 10/27/15.
-//  Copyright © 2015 nerdish by nature. All rights reserved.
-//
-
 import Foundation
 
 public extension Octokit {

--- a/OctoKitTests/StarsTests.swift
+++ b/OctoKitTests/StarsTests.swift
@@ -1,0 +1,123 @@
+import XCTest
+import OctoKit
+import Nocilla
+
+class StarsTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        LSNocilla.sharedInstance().start()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        LSNocilla.sharedInstance().clearStubs()
+        LSNocilla.sharedInstance().stop()
+    }
+
+    // MARK: URLRequest Tests
+
+    func testReadStarsURLRequest() {
+        let kit = Octokit(TokenConfiguration("12345"))
+        let request = StarsRouter.ReadStars("octocat", kit).URLRequest
+        XCTAssertEqual(request!.URL!, NSURL(string: "https://api.github.com/users/octocat/starred?access_token=12345")!)
+    }
+
+    func testMyStarsURLRequest() {
+        let kit = Octokit(TokenConfiguration("12345"))
+        let request = StarsRouter.ReadAuthenticatedStars(kit).URLRequest
+        XCTAssertEqual(request!.URL!, NSURL(string: "https://api.github.com/user/starred?access_token=12345")!)
+    }
+
+    // MARK: Actual Request tests
+
+    func testGetStarredRepositories() {
+        let config = TokenConfiguration("12345")
+        if let json = Helper.stringFromFile("user_repos") {
+            stubRequest("GET", "https://api.github.com/user/starred?access_token=12345").andReturn(200).withHeaders(["Content-Type": "application/json"]).withBody(json)
+            let expectation = expectationWithDescription("user_starred")
+            Octokit(config).myStars() { response in
+                switch response {
+                case .Success(let repositories):
+                    XCTAssertEqual(repositories.count, 1)
+                    expectation.fulfill()
+                case .Failure:
+                    XCTAssert(false, "should not get an error")
+                    expectation.fulfill()
+                }
+            }
+            waitForExpectationsWithTimeout(1) { (error) in
+                XCTAssertNil(error, "\(error)")
+            }
+        } else {
+            XCTFail("json shouldn't be nil")
+        }
+    }
+
+    func testFailToGetStarredRepositories() {
+        let config = TokenConfiguration("12345")
+        stubRequest("GET", "https://api.github.com/user/starred?access_token=12345").andReturn(404)
+        let expectation = expectationWithDescription("failing_starred")
+        Octokit(config).myStars() { response in
+            switch response {
+            case .Success:
+                XCTAssert(false, "should not retrieve repositories")
+                expectation.fulfill()
+            case .Failure(let error as NSError):
+                XCTAssertEqual(error.code, 404)
+                XCTAssertEqual(error.domain, "com.octokit.swift")
+                expectation.fulfill()
+            case .Failure:
+                XCTAssertTrue(false)
+                expectation.fulfill()
+            }
+        }
+        waitForExpectationsWithTimeout(1) { error in
+            XCTAssertNil(error, "\(error)")
+        }
+    }
+
+    func testGetUsersStarredRepositories() {
+        if let json = Helper.stringFromFile("user_repos") {
+            stubRequest("GET", "https://api.github.com/users/octocat/starred").andReturn(200).withHeaders(["Content-Type": "application/json"]).withBody(json)
+            let expectation = expectationWithDescription("users_starred")
+            Octokit().stars("octocat") { response in
+                switch response {
+                case .Success(let repositories):
+                    XCTAssertEqual(repositories.count, 1)
+                    expectation.fulfill()
+                case .Failure:
+                    XCTAssert(false, "should not get an error")
+                    expectation.fulfill()
+                }
+            }
+            waitForExpectationsWithTimeout(1) { (error) in
+                XCTAssertNil(error, "\(error)")
+            }
+        } else {
+            XCTFail("json shouldn't be nil")
+        }
+    }
+
+    func testFailToGetUsersStarredRepositories() {
+        stubRequest("GET", "https://api.github.com/users/octocat/starred").andReturn(404)
+        let expectation = expectationWithDescription("failing_starred")
+        Octokit().stars("octocat") { response in
+            switch response {
+            case .Success:
+                XCTAssert(false, "should not retrieve repositories")
+                expectation.fulfill()
+            case .Failure(let error as NSError):
+                XCTAssertEqual(error.code, 404)
+                XCTAssertEqual(error.domain, "com.octokit.swift")
+                expectation.fulfill()
+            case .Failure:
+                XCTAssertTrue(false)
+                expectation.fulfill()
+            }
+        }
+        waitForExpectationsWithTimeout(1) { error in
+            XCTAssertNil(error, "\(error)")
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -156,3 +156,33 @@ Octokit().repositories() { response in
   }
 }
 ```
+
+## Starred Repositories
+
+### Get starred repositories of some user
+
+```swift
+let username = "username"
+Octokit().stars(username) { response in
+  switch response {
+    case .Success(let repositories):
+      // do something with the repositories
+    case .Failure(let error):
+      // handle any errors
+  }
+}
+```
+
+### Get starred repositories of authenticated user
+
+```swift
+Octokit().myStars() { response in
+  switch response {
+    case .Success(let repositories):
+      // do something with the repositories
+    case .Failure(let error):
+      // handle any errors
+  }
+}
+```
+


### PR DESCRIPTION
Implementing these two calls:
- `GET /users/:username/starred`
- `GET /user/starred`