### PR TITLE
Repos for arbitrary user

### DIFF
--- a/OctoKit/Repositories.swift
+++ b/OctoKit/Repositories.swift
@@ -41,7 +41,7 @@ import RequestKit
 
 public extension Octokit {
     public func repositories(page: String = "1", perPage: String = "100", completion: (response: Response<[Repository]>) -> Void) {
-        let router = RepositoryRouter.ReadRepositories(configuration, page, perPage)
+        let router = RepositoryRouter.ReadAuthenticatedRepositories(configuration, page, perPage)
         router.loadJSON([[String: AnyObject]].self) { json, error in
             if let error = error {
                 completion(response: Response.Failure(error))
@@ -72,12 +72,12 @@ public extension Octokit {
 // MARK: Router
 
 public enum RepositoryRouter: Router {
-    case ReadRepositories(Configuration, String, String)
+    case ReadAuthenticatedRepositories(Configuration, String, String)
     case ReadRepository(Configuration, String, String)
 
     public var configuration: Configuration {
         switch self {
-        case .ReadRepositories(let config, _, _): return config
+        case .ReadAuthenticatedRepositories(let config, _, _): return config
         case .ReadRepository(let config, _, _): return config
         }
     }
@@ -92,7 +92,7 @@ public enum RepositoryRouter: Router {
 
     public var params: [String: String] {
         switch self {
-        case .ReadRepositories(_, let page, let perPage):
+        case .ReadAuthenticatedRepositories(_, let page, let perPage):
             return ["per_page": perPage, "page": page]
         case .ReadRepository:
             return [:]
@@ -101,7 +101,7 @@ public enum RepositoryRouter: Router {
 
     public var path: String {
         switch self {
-        case .ReadRepositories:
+        case .ReadAuthenticatedRepositories:
             return "/user/repos"
         case .ReadRepository(_, let owner, let name):
             return "/repos/\(owner)/\(name)"
@@ -110,7 +110,7 @@ public enum RepositoryRouter: Router {
 
     public var URLRequest: NSURLRequest? {
         switch self {
-        case .ReadRepositories(_, _, _):
+        case .ReadAuthenticatedRepositories(_, _, _):
             return request()
         case .ReadRepository(_, _, _):
             return request()

--- a/OctoKit/Repositories.swift
+++ b/OctoKit/Repositories.swift
@@ -72,11 +72,13 @@ public extension Octokit {
 // MARK: Router
 
 public enum RepositoryRouter: Router {
+    case ReadRepositories(String, String)
     case ReadAuthenticatedRepositories(Configuration, String, String)
     case ReadRepository(Configuration, String, String)
 
     public var configuration: Configuration {
         switch self {
+        case .ReadRepositories(_, _): return TokenConfiguration()
         case .ReadAuthenticatedRepositories(let config, _, _): return config
         case .ReadRepository(let config, _, _): return config
         }
@@ -92,6 +94,8 @@ public enum RepositoryRouter: Router {
 
     public var params: [String: String] {
         switch self {
+        case .ReadRepositories(let page, let perPage):
+            return ["per_page": perPage, "page": page]
         case .ReadAuthenticatedRepositories(_, let page, let perPage):
             return ["per_page": perPage, "page": page]
         case .ReadRepository:
@@ -101,6 +105,8 @@ public enum RepositoryRouter: Router {
 
     public var path: String {
         switch self {
+        case ReadRepositories:
+            return "/users/:username/repos"
         case .ReadAuthenticatedRepositories:
             return "/user/repos"
         case .ReadRepository(_, let owner, let name):
@@ -110,6 +116,8 @@ public enum RepositoryRouter: Router {
 
     public var URLRequest: NSURLRequest? {
         switch self {
+        case .ReadRepositories(_, _):
+            return request()
         case .ReadAuthenticatedRepositories(_, _, _):
             return request()
         case .ReadRepository(_, _, _):

--- a/OctoKitTests/RepositoryTests.swift
+++ b/OctoKitTests/RepositoryTests.swift
@@ -48,6 +48,28 @@ class RepositoryTests: XCTestCase {
     // MARK: Actual Request tests
 
     func testGetRepositories() {
+        if let json = Helper.stringFromFile("user_repos") {
+            stubRequest("GET", "https://api.github.com/users/octocat/repos?page=1&per_page=100").andReturn(200).withHeaders(["Content-Type": "application/json"]).withBody(json)
+            let expectation = expectationWithDescription("user_repos")
+            Octokit().repositories("octocat") { response in
+                switch response {
+                case .Success(let repositories):
+                    XCTAssertEqual(repositories.count, 1)
+                    expectation.fulfill()
+                case .Failure:
+                    XCTAssert(false, "should not get an error")
+                    expectation.fulfill()
+                }
+            }
+            waitForExpectationsWithTimeout(1) { (error) in
+                XCTAssertNil(error, "\(error)")
+            }
+        } else {
+            XCTFail("json shouldn't be nil")
+        }
+    }
+
+    func testGetAuthenticatedRepositories() {
         let config = TokenConfiguration("12345")
         if let json = Helper.stringFromFile("user_repos") {
             stubRequest("GET", "https://api.github.com/user/repos?access_token=12345&page=1&per_page=100").andReturn(200).withHeaders(["Content-Type": "application/json"]).withBody(json)

--- a/OctoKitTests/RepositoryTests.swift
+++ b/OctoKitTests/RepositoryTests.swift
@@ -16,6 +16,18 @@ class RepositoryTests: XCTestCase {
 
     // MARK: URLRequest Tests
 
+    func testReadRepositoriesURLRequest() {
+        let kit = Octokit(TokenConfiguration())
+        let request = RepositoryRouter.ReadRepositories(kit.configuration, "octocat", "1", "100").URLRequest
+        XCTAssertEqual(request!.URL!, NSURL(string: "https://api.github.com/users/octocat/repos?page=1&per_page=100")!)
+    }
+
+    func testReadRepositoriesURLRequestWithCustomPageAndPerPage() {
+        let kit = Octokit(TokenConfiguration())
+        let request = RepositoryRouter.ReadRepositories(kit.configuration, "octocat", "5", "50").URLRequest
+        XCTAssertEqual(request!.URL!, NSURL(string: "https://api.github.com/users/octocat/repos?page=5&per_page=50")!)
+    }
+
     func testReadAuthenticatedRepositoriesURLRequest() {
         let kit = Octokit(TokenConfiguration("12345"))
         let request = RepositoryRouter.ReadAuthenticatedRepositories(kit.configuration, "1", "100").URLRequest

--- a/OctoKitTests/RepositoryTests.swift
+++ b/OctoKitTests/RepositoryTests.swift
@@ -16,15 +16,15 @@ class RepositoryTests: XCTestCase {
 
     // MARK: URLRequest Tests
 
-    func testReadRepositoriesURLRequest() {
+    func testReadAuthenticatedRepositoriesURLRequest() {
         let kit = Octokit(TokenConfiguration("12345"))
-        let request = RepositoryRouter.ReadRepositories(kit.configuration, "1", "100").URLRequest
+        let request = RepositoryRouter.ReadAuthenticatedRepositories(kit.configuration, "1", "100").URLRequest
         XCTAssertEqual(request!.URL!, NSURL(string: "https://api.github.com/user/repos?access_token=12345&page=1&per_page=100")!)
     }
 
-    func testReadRepositoriesURLRequestWithCustomPageAndPerPage() {
+    func testReadAuthenticatedRepositoriesURLRequestWithCustomPageAndPerPage() {
         let kit = Octokit(TokenConfiguration("12345"))
-        let request = RepositoryRouter.ReadRepositories(kit.configuration, "5", "50").URLRequest
+        let request = RepositoryRouter.ReadAuthenticatedRepositories(kit.configuration, "5", "50").URLRequest
         XCTAssertEqual(request!.URL!, NSURL(string: "https://api.github.com/user/repos?access_token=12345&page=5&per_page=50")!)
     }
 


### PR DESCRIPTION
Extended the `Octokit.repositories` API to take an owner parameter so that any user's repos can be enumerated. I'm not excited about the `?:` conditional to load the correct router, but this was enough to get it to work. Let me know what your thoughts are about the API and I can rework this.