### PR TITLE
Remove Routers from public API

### DIFF
--- a/OctoKit/Configuration.swift
+++ b/OctoKit/Configuration.swift
@@ -74,18 +74,18 @@ public struct OAuthConfiguration: Configuration {
     }
 }
 
-public enum OAuthRouter: Router {
+enum OAuthRouter: Router {
     case Authorize(OAuthConfiguration)
     case AccessToken(OAuthConfiguration, String)
 
-    public var configuration: Configuration {
+    var configuration: Configuration {
         switch self {
         case .Authorize(let config): return config
         case .AccessToken(let config, _): return config
         }
     }
 
-    public var method: HTTPMethod {
+    var method: HTTPMethod {
         switch self {
         case .Authorize:
             return .GET
@@ -94,7 +94,7 @@ public enum OAuthRouter: Router {
         }
     }
 
-    public var encoding: HTTPEncoding {
+    var encoding: HTTPEncoding {
         switch self {
         case .Authorize:
             return .URL
@@ -103,7 +103,7 @@ public enum OAuthRouter: Router {
         }
     }
 
-    public var path: String {
+    var path: String {
         switch self {
         case .Authorize:
             return "login/oauth/authorize"
@@ -112,7 +112,7 @@ public enum OAuthRouter: Router {
         }
     }
 
-    public var params: [String: String] {
+    var params: [String: String] {
         switch self {
         case .Authorize(let config):
             let scope = (config.scopes as NSArray).componentsJoinedByString(",")
@@ -122,7 +122,7 @@ public enum OAuthRouter: Router {
         }
     }
 
-    public var URLRequest: NSURLRequest? {
+    var URLRequest: NSURLRequest? {
         switch self {
         case .Authorize(let config):
             let URLString = config.webEndpoint.stringByAppendingURLPath(path)

--- a/OctoKit/Follow.swift
+++ b/OctoKit/Follow.swift
@@ -59,21 +59,21 @@ public extension Octokit {
     }
 }
 
-public enum FollowRouter: Router {
+enum FollowRouter: Router {
     case ReadAuthenticatedFollowers(Configuration)
     case ReadFollowers(String, Configuration)
     case ReadAuthenticatedFollowing(Configuration)
     case ReadFollowing(String, Configuration)
 
-    public var method: HTTPMethod {
+    var method: HTTPMethod {
         return .GET
     }
 
-    public var encoding: HTTPEncoding {
+    var encoding: HTTPEncoding {
         return .URL
     }
 
-    public var configuration: Configuration {
+    var configuration: Configuration {
         switch self {
         case .ReadAuthenticatedFollowers(let config): return config
         case .ReadFollowers(_, let config): return config
@@ -82,7 +82,7 @@ public enum FollowRouter: Router {
         }
     }
 
-    public var path: String {
+    var path: String {
         switch self {
         case .ReadAuthenticatedFollowers:
             return "user/followers"
@@ -95,11 +95,11 @@ public enum FollowRouter: Router {
         }
     }
 
-    public var params: [String: String] {
+    var params: [String: String] {
         return [:]
     }
 
-    public var URLRequest: NSURLRequest? {
+    var URLRequest: NSURLRequest? {
         return request()
     }
 }

--- a/OctoKit/PublicKey.swift
+++ b/OctoKit/PublicKey.swift
@@ -18,44 +18,44 @@ public extension Octokit {
     }
 }
 
-public enum PublicKeyRouter: JSONPostRouter {
+enum PublicKeyRouter: JSONPostRouter {
     case PostPublicKey(String, String, Configuration)
 
-    public var configuration: Configuration {
+    var configuration: Configuration {
         switch self {
         case .PostPublicKey(_, _, let config): return config
         }
     }
 
-    public var method: HTTPMethod {
+    var method: HTTPMethod {
         switch self {
         case .PostPublicKey:
             return .POST
         }
     }
 
-    public var encoding: HTTPEncoding {
+    var encoding: HTTPEncoding {
         switch self {
         case .PostPublicKey:
             return .JSON
         }
     }
 
-    public var path: String {
+    var path: String {
         switch self {
         case .PostPublicKey:
             return "user/keys"
         }
     }
 
-    public var params: [String: String] {
+    var params: [String: String] {
         switch self {
         case .PostPublicKey(let publicKey, let title, _):
             return ["title": title, "key": publicKey]
         }
     }
 
-    public var URLRequest: NSURLRequest? {
+    var URLRequest: NSURLRequest? {
         switch self {
         case .PostPublicKey(_, _, _):
             return request()

--- a/OctoKit/Repositories.swift
+++ b/OctoKit/Repositories.swift
@@ -77,12 +77,12 @@ public extension Octokit {
 
 // MARK: Router
 
-public enum RepositoryRouter: Router {
+enum RepositoryRouter: Router {
     case ReadRepositories(Configuration, String, String, String)
     case ReadAuthenticatedRepositories(Configuration, String, String)
     case ReadRepository(Configuration, String, String)
 
-    public var configuration: Configuration {
+    var configuration: Configuration {
         switch self {
         case .ReadRepositories(let config, _, _, _): return config
         case .ReadAuthenticatedRepositories(let config, _, _): return config
@@ -90,15 +90,15 @@ public enum RepositoryRouter: Router {
         }
     }
 
-    public var method: HTTPMethod {
+    var method: HTTPMethod {
         return .GET
     }
 
-    public var encoding: HTTPEncoding {
+    var encoding: HTTPEncoding {
         return .URL
     }
 
-    public var params: [String: String] {
+    var params: [String: String] {
         switch self {
         case .ReadRepositories(_, _, let page, let perPage):
             return ["per_page": perPage, "page": page]
@@ -109,7 +109,7 @@ public enum RepositoryRouter: Router {
         }
     }
 
-    public var path: String {
+    var path: String {
         switch self {
         case ReadRepositories(_, let owner, _, _):
             return "/users/\(owner)/repos"
@@ -120,7 +120,7 @@ public enum RepositoryRouter: Router {
         }
     }
 
-    public var URLRequest: NSURLRequest? {
+    var URLRequest: NSURLRequest? {
         switch self {
         case .ReadRepositories(_, _, _, _):
             return request()

--- a/OctoKit/Stars.swift
+++ b/OctoKit/Stars.swift
@@ -31,25 +31,25 @@ public extension Octokit {
     }
 }
 
-public enum StarsRouter: Router {
+enum StarsRouter: Router {
     case ReadAuthenticatedStars(Configuration)
     case ReadStars(String, Configuration)
-    public var method: HTTPMethod {
+    var method: HTTPMethod {
         return .GET
     }
 
-    public var configuration: Configuration {
+    var configuration: Configuration {
         switch self {
         case .ReadAuthenticatedStars(let config): return config
         case .ReadStars(_, let config): return config
         }
     }
 
-    public var encoding: HTTPEncoding {
+    var encoding: HTTPEncoding {
         return .URL
     }
 
-    public var path: String {
+    var path: String {
         switch self {
         case .ReadAuthenticatedStars:
             return "user/starred"
@@ -58,11 +58,11 @@ public enum StarsRouter: Router {
         }
     }
 
-    public var params: [String: String] {
+    var params: [String: String] {
         return [:]
     }
 
-    public var URLRequest: NSURLRequest? {
+    var URLRequest: NSURLRequest? {
         return request()
     }
 }

--- a/OctoKit/User.swift
+++ b/OctoKit/User.swift
@@ -73,26 +73,26 @@ public extension Octokit {
 
 // MARK: Router
 
-public enum UserRouter: Router {
+enum UserRouter: Router {
     case ReadAuthenticatedUser(Configuration)
     case ReadUser(String, Configuration)
 
-    public var configuration: Configuration {
+    var configuration: Configuration {
         switch self {
         case .ReadAuthenticatedUser(let config): return config
         case .ReadUser(_, let config): return config
         }
     }
 
-    public var method: HTTPMethod {
+    var method: HTTPMethod {
         return .GET
     }
 
-    public var encoding: HTTPEncoding {
+    var encoding: HTTPEncoding {
         return .URL
     }
 
-    public var path: String {
+    var path: String {
         switch self {
         case .ReadAuthenticatedUser:
             return "user"
@@ -101,11 +101,11 @@ public enum UserRouter: Router {
         }
     }
 
-    public var params: [String: String] {
+    var params: [String: String] {
         return [:]
     }
 
-    public var URLRequest: NSURLRequest? {
+    var URLRequest: NSURLRequest? {
         switch self {
         case .ReadAuthenticatedUser(_):
             return request()

--- a/OctoKitTests/ConfigurationTests.swift
+++ b/OctoKitTests/ConfigurationTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import Foundation
-import OctoKit
+@testable import OctoKit
 import Nocilla
 
 class ConfigurationTests: XCTestCase {

--- a/OctoKitTests/FollowTests.swift
+++ b/OctoKitTests/FollowTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import OctoKit
+@testable import OctoKit
 import Nocilla
 
 class FollowTests: XCTestCase {

--- a/OctoKitTests/PublicKeyTests.swift
+++ b/OctoKitTests/PublicKeyTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import OctoKit
+@testable import OctoKit
 import Nocilla
 
 class PublicKeyTests: XCTestCase {

--- a/OctoKitTests/RepositoryTests.swift
+++ b/OctoKitTests/RepositoryTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import OctoKit
+@testable import OctoKit
 import Nocilla
 
 class RepositoryTests: XCTestCase {

--- a/OctoKitTests/StarsTests.swift
+++ b/OctoKitTests/StarsTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import OctoKit
+@testable import OctoKit
 import Nocilla
 
 class StarsTests: XCTestCase {

--- a/OctoKitTests/UserTests.swift
+++ b/OctoKitTests/UserTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import OctoKit
+@testable import OctoKit
 import Nocilla
 
 class UserTests: XCTestCase {


### PR DESCRIPTION
These Routers are implementation details of the calls, and don't really need to be exposed to the public API. `@testable` allows us to still include them in the specs.