### PR TITLE
Remove NBNRequestKit version from podspec

### DIFF
--- a/OctoKit.swift.podspec
+++ b/OctoKit.swift.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/nerdishbynature/octokit.swift.git", :tag => s.version.to_s }
   s.social_media_url = "https://twitter.com/pietbrauer"
   s.module_name     = "Octokit"
-  s.dependency "NBNRequestKit", "~> 0.3.0"
+  s.dependency "NBNRequestKit"
   s.requires_arc = true
   s.source_files = "OctoKit/*.swift"
   s.ios.deployment_target = '8.0'


### PR DESCRIPTION
In order for a project to use this Swift 2.3 branch, it also needs to use RequestKit’s Swift 2.3 branch by overriding the NBNRequestKit entry in the Podfile:

```rb
pod 'NBNRequestKit', :git => 'https://github.com/nerdishbynature/RequestKit.git', :branch => 'swift-2.3'
```

This PR removes the version requirement from the NBNRequestKit dependency, resolving the conflict that arises when the Podfile specifies an external source for NBNRequestKit:

```
[!] Unable to satisfy the following requirements:

- `NBNRequestKit (from `https://github.com/nerdishbynature/RequestKit.git`, branch `swift-2.3`)` required by `Podfile`
- `NBNRequestKit (from `https://github.com/nerdishbynature/RequestKit.git`, branch `swift-2.3`)` required by `Podfile`
- `NBNRequestKit (from `https://github.com/nerdishbynature/RequestKit.git`, branch `swift-2.3`)` required by `Podfile`
- `NBNRequestKit (~> 0.3.0)` required by `OctoKit.swift (0.6.1)`
```

/ref #45
/cc @pietbrauer