### PR TITLE
Handle undocumented optional parameters in Redirect URL

### DIFF
--- a/OctoKit.xcodeproj/project.pbxproj
+++ b/OctoKit.xcodeproj/project.pbxproj
@@ -21,6 +21,10 @@
 		234F4BE11BDDE44600A58EF7 /* user_repos.json in Resources */ = {isa = PBXBuildFile; fileRef = 234F4BDC1BDDE44600A58EF7 /* user_repos.json */; };
 		234F4C3F1BDE0FE200A58EF7 /* RequestKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 234F4C3E1BDE0FE200A58EF7 /* RequestKit.framework */; };
 		234F4C401BDE113800A58EF7 /* RequestKit.framework in Carthage embed */ = {isa = PBXBuildFile; fileRef = 234F4C3E1BDE0FE200A58EF7 /* RequestKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		237F91E41E5AEC82005FAA6B /* URL+URLParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 237F91E31E5AEC82005FAA6B /* URL+URLParameters.swift */; };
+		237F91E51E5AEC87005FAA6B /* URL+URLParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 237F91E31E5AEC82005FAA6B /* URL+URLParameters.swift */; };
+		237F91E61E5AEC88005FAA6B /* URL+URLParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 237F91E31E5AEC82005FAA6B /* URL+URLParameters.swift */; };
+		237F91E71E5AEC89005FAA6B /* URL+URLParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 237F91E31E5AEC82005FAA6B /* URL+URLParameters.swift */; };
 		239BE7CE1B8C47A100D2CE22 /* OctoKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 239BE7CD1B8C47A100D2CE22 /* OctoKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		23A0521F1CA924950068BFF7 /* OctoKitURLTestSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A0521E1CA924950068BFF7 /* OctoKitURLTestSession.swift */; };
 		23A052201CA924950068BFF7 /* OctoKitURLTestSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A0521E1CA924950068BFF7 /* OctoKitURLTestSession.swift */; };
@@ -196,6 +200,7 @@
 		234F4BDB1BDDE44600A58EF7 /* user_mietzmithut.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = user_mietzmithut.json; path = Fixtures/user_mietzmithut.json; sourceTree = "<group>"; };
 		234F4BDC1BDDE44600A58EF7 /* user_repos.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = user_repos.json; path = Fixtures/user_repos.json; sourceTree = "<group>"; };
 		234F4C3E1BDE0FE200A58EF7 /* RequestKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RequestKit.framework; path = Carthage/Build/iOS/RequestKit.framework; sourceTree = "<group>"; };
+		237F91E31E5AEC82005FAA6B /* URL+URLParameters.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "URL+URLParameters.swift"; sourceTree = "<group>"; };
 		239BE7C91B8C47A100D2CE22 /* OctoKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OctoKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		239BE7CC1B8C47A100D2CE22 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		239BE7CD1B8C47A100D2CE22 /* OctoKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OctoKit.h; sourceTree = "<group>"; };
@@ -339,6 +344,7 @@
 				23B267891BDDD756003887E3 /* User.swift */,
 				E7EE59D71BDFEFB30012E3D2 /* Stars.swift */,
 				F8711EA11BFCAE9F005DDACA /* Time.swift */,
+				237F91E31E5AEC82005FAA6B /* URL+URLParameters.swift */,
 				239BE7CB1B8C47A100D2CE22 /* Supporting Files */,
 			);
 			path = OctoKit;
@@ -724,6 +730,7 @@
 				F8711EA21BFCAE9F005DDACA /* Time.swift in Sources */,
 				23B2678C1BDDD756003887E3 /* PublicKey.swift in Sources */,
 				23B2678E1BDDD756003887E3 /* User.swift in Sources */,
+				237F91E41E5AEC82005FAA6B /* URL+URLParameters.swift in Sources */,
 				DAEFC5951C83EF0D00CF3785 /* Milestone.swift in Sources */,
 				23B2678B1BDDD756003887E3 /* Octokit.swift in Sources */,
 				E7EDEA6A1C871CEB006BAAF2 /* Issue.swift in Sources */,
@@ -742,6 +749,7 @@
 				23CAF2B71C7AB6EB005011C4 /* Time.swift in Sources */,
 				23CAF2B41C7AB6D4005011C4 /* Stars.swift in Sources */,
 				23CAF2AB1C7AB6C9005011C4 /* PublicKey.swift in Sources */,
+				237F91E51E5AEC87005FAA6B /* URL+URLParameters.swift in Sources */,
 				DAEFC5961C83EF0D00CF3785 /* Milestone.swift in Sources */,
 				23CAF2A81C7AB6C6005011C4 /* Octokit.swift in Sources */,
 				E7EDEA6F1C871F81006BAAF2 /* Issue.swift in Sources */,
@@ -777,6 +785,7 @@
 				23CAF2B81C7AB6EB005011C4 /* Time.swift in Sources */,
 				23CAF2B51C7AB6D5005011C4 /* Stars.swift in Sources */,
 				23CAF2AC1C7AB6CA005011C4 /* PublicKey.swift in Sources */,
+				237F91E61E5AEC88005FAA6B /* URL+URLParameters.swift in Sources */,
 				DAEFC5971C83EF0D00CF3785 /* Milestone.swift in Sources */,
 				23CAF2A91C7AB6C6005011C4 /* Octokit.swift in Sources */,
 				E7EDEA701C871F81006BAAF2 /* Issue.swift in Sources */,
@@ -812,6 +821,7 @@
 				23CAF2B91C7AB6EC005011C4 /* Time.swift in Sources */,
 				23CAF2B61C7AB6D5005011C4 /* Stars.swift in Sources */,
 				23CAF2AD1C7AB6CA005011C4 /* PublicKey.swift in Sources */,
+				237F91E71E5AEC89005FAA6B /* URL+URLParameters.swift in Sources */,
 				DAEFC5981C83EF0D00CF3785 /* Milestone.swift in Sources */,
 				23CAF2AA1C7AB6C7005011C4 /* Octokit.swift in Sources */,
 				E7EDEA711C871F82006BAAF2 /* Issue.swift in Sources */,

--- a/OctoKit/Configuration.swift
+++ b/OctoKit/Configuration.swift
@@ -63,7 +63,7 @@ public struct OAuthConfiguration: Configuration {
 
     public func handleOpenURL(_ session: RequestKitURLSession = URLSession.shared, url: URL, completion: @escaping (_ config: TokenConfiguration) -> Void) {
         let urlString: String? = url.absoluteString
-        if let code = urlString?.components(separatedBy: "=").last {
+        if let code = url.URLParameters["code"] {
             authorize(session, code: code) { (config) in
                 completion(config)
             }

--- a/OctoKit/Configuration.swift
+++ b/OctoKit/Configuration.swift
@@ -62,7 +62,6 @@ public struct OAuthConfiguration: Configuration {
     }
 
     public func handleOpenURL(_ session: RequestKitURLSession = URLSession.shared, url: URL, completion: @escaping (_ config: TokenConfiguration) -> Void) {
-        let urlString: String? = url.absoluteString
         if let code = url.URLParameters["code"] {
             authorize(session, code: code) { (config) in
                 completion(config)

--- a/OctoKit/URL+URLParameters.swift
+++ b/OctoKit/URL+URLParameters.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+internal extension URL {
+    var URLParameters: [String: String] {
+        let stringParams = absoluteString.components(separatedBy: "?").last
+        let params = stringParams?.components(separatedBy: "&")
+        var returnParams: [String: String] = [:]
+        if let params = params {
+            for param in params {
+                let keyValue = param.components(separatedBy: "=")
+                if let key = keyValue.first, let value = keyValue.last {
+                    returnParams[key] = value
+                }
+            }
+        }
+        return returnParams
+    }
+}

--- a/OctoKit/URL+URLParameters.swift
+++ b/OctoKit/URL+URLParameters.swift
@@ -2,17 +2,11 @@ import Foundation
 
 internal extension URL {
     var URLParameters: [String: String] {
-        let stringParams = absoluteString.components(separatedBy: "?").last
-        let params = stringParams?.components(separatedBy: "&")
-        var returnParams: [String: String] = [:]
-        if let params = params {
-            for param in params {
-                let keyValue = param.components(separatedBy: "=")
-                if let key = keyValue.first, let value = keyValue.last {
-                    returnParams[key] = value
-                }
-            }
+        guard let components = URLComponents(url: self, resolvingAgainstBaseURL: false) else { return [:] }
+        var params = [String: String]()
+        components.queryItems?.forEach { queryItem in
+            params[queryItem.name] = queryItem.value
         }
-        return returnParams
+        return params
     }
 }

--- a/OctoKitTests/ConfigurationTests.swift
+++ b/OctoKitTests/ConfigurationTests.swift
@@ -40,7 +40,7 @@ class ConfigurationTests: XCTestCase {
         let config = OAuthConfiguration(token: "12345", secret: "6789", scopes: ["repo", "read:org"])
         let response = "access_token=017ec60f4a182&scope=read%3Aorg%2Crepo&token_type=bearer"
         let session = OctoKitURLTestSession(expectedURL: "https://github.com/login/oauth/access_token", expectedHTTPMethod: "POST", response: response, statusCode: 200)
-        let url = URL(string: "urlscheme://authorize?code=dhfjgh23493")!
+        let url = URL(string: "urlscheme://authorize?code=dhfjgh23493&state=")!
         var token: String? = nil
         config.handleOpenURL(session, url: url) { accessToken in
             token = accessToken.accessToken


### PR DESCRIPTION
Since last week (around 17/2/2017) GitHub is appending the optional and unset `state` parameter to the redirect URI, which is unhandled (we take the last component from the URL).

This updates the framework to produce a dictionary from the URL parameters.