### PR TITLE
Add support for Swift Package Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ fastlane/report.xml
 Pods/
 Carthage/
 Checkouts/
+
+# Swift PM
+.build
+Package.resolved

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ script:
   - set -o pipefail
   - bundle exec fastlane $FASTLANE_LANE configuration:Debug --env $FASTLANE_ENV
   - bundle exec fastlane $FASTLANE_LANE configuration:Release --env $FASTLANE_ENV
-  - swift test
 after_success:
   - if [ "$FASTLANE_LANE" == "code_coverage" ]; then
      make post_coverage;

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ script:
   - set -o pipefail
   - bundle exec fastlane $FASTLANE_LANE configuration:Debug --env $FASTLANE_ENV
   - bundle exec fastlane $FASTLANE_LANE configuration:Release --env $FASTLANE_ENV
+  - swift test
 after_success:
   - if [ "$FASTLANE_LANE" == "code_coverage" ]; then
      make post_coverage;

--- a/OctoKitTests/TestHelper.swift
+++ b/OctoKitTests/TestHelper.swift
@@ -28,7 +28,7 @@ internal class Helper {
             path = bundlePath
         }
         else {
-            let bundle = Bundle(path: "Fixtures")
+            let bundle = Bundle(path: "OctoKitTests/Fixtures")
             path = bundle!.path(forResource: name, ofType: "json")!
         }
         let data = try! Data(contentsOf: URL(fileURLWithPath: path))

--- a/OctoKitTests/TestHelper.swift
+++ b/OctoKitTests/TestHelper.swift
@@ -22,8 +22,15 @@ internal class Helper {
     }
 
     internal class func codableFromFile<T>(_ name: String, type: T.Type) -> T where T: Codable {
+        var path: String
         let bundle = Bundle(for: self)
-        let path = bundle.path(forResource: name, ofType: "json")!
+        if let bundlePath = bundle.path(forResource: name, ofType: "json") {
+            path = bundlePath
+        }
+        else {
+            let bundle = Bundle(path: "Fixtures")
+            path = bundle!.path(forResource: name, ofType: "json")!
+        }
         let data = try! Data(contentsOf: URL(fileURLWithPath: path))
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(Time.rfc3339DateFormatter)

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:4.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["OctoKit"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/shkhaliq/RequestKit", .branch("support-for-swift4")),
+        .package(url: "https://github.com/nerdishbynature/RequestKit.git", .branch("master")),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,29 @@
+// swift-tools-version:4.2
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "OctoKit",
+
+    products: [
+        .library(
+            name: "OctoKit",
+            targets: ["OctoKit"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/shkhaliq/RequestKit", .branch("support-for-swift4")),
+    ],
+    targets: [
+        .target(
+            name: "OctoKit",
+            dependencies: ["RequestKit"],
+            path: ".",
+            sources: ["OctoKit"]),
+        .testTarget(
+            name: "OctoKitTests",
+            dependencies: ["OctoKit"],
+            path: "OctoKitTests",
+            sources: ["."]),
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["OctoKit"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/nerdishbynature/RequestKit.git", .branch("master")),
+        .package(url: "https://github.com/nerdishbynature/RequestKit.git", .exact("2.3.0")),
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -1,7 +1,23 @@
 # Octokit.swift
 
 [![Build Status](https://travis-ci.org/nerdishbynature/octokit.swift.svg?branch=master)](https://travis-ci.org/nerdishbynature/octokit.swift)
+[![CocoaPods](https://img.shields.io/cocoapods/v/OctoKit.swift.svg)](https://cocoapods.org/pods/OctoKit.swift)
 [![codecov.io](https://codecov.io/github/nerdishbynature/octokit.swift/coverage.svg?branch=master)](https://codecov.io/github/nerdishbynature/octokit.swift?branch=master)
+
+## Installation
+
+- **Using [Swift Package Manager](https://swift.org/package-manager)**:
+
+    ```swift
+    import PackageDescription
+
+    let package = Package(
+      name: "MyAwesomeApp",
+      dependencies: [
+        .Package(url: "https://github.com/nerdishbynature/octokit.swift", from: "0.8.0"),
+      ]
+    )
+    ```
 
 ## Authentication
 

--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@
 
 - **Using [Swift Package Manager](https://swift.org/package-manager)**:
 
-    ```swift
-    import PackageDescription
+```swift
+import PackageDescription
 
-    let package = Package(
-      name: "MyAwesomeApp",
-      dependencies: [
-        .Package(url: "https://github.com/nerdishbynature/octokit.swift", from: "0.8.0"),
-      ]
-    )
-    ```
+let package = Package(
+  name: "MyAwesomeApp",
+    dependencies: [
+      .Package(url: "https://github.com/nerdishbynature/octokit.swift", from: "0.8.0"),
+    ]
+  )
+```
 
 ## Authentication
 


### PR DESCRIPTION
Adds support for Swift Package Manager
Added steps for installation in the README
Added badge for the version of the cocoapod

### Concerns

* I made changes to the `codableFromFile` method and the reasoning was so that I could run tests from the commandline `swift test` but the are sources that are copied over using bundle resources but Swift PM doesn't support it.
  * I am happy to remove those changes if we don't want to support SPM going forward