### PR TITLE
Allow GitHub API calls to be discarded

### DIFF
--- a/OctoKit/Follow.swift
+++ b/OctoKit/Follow.swift
@@ -8,6 +8,7 @@ public extension Octokit {
         - parameter session: RequestKitURLSession, defaults to NSURLSession.sharedSession()
         - parameter completion: Callback for the outcome of the fetch.
     */
+    @discardableResult
     public func myFollowers(_ session: RequestKitURLSession = URLSession.shared, completion: @escaping (_ response: Response<[User]>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = FollowRouter.readAuthenticatedFollowers(configuration)
         return router.load(session, expectedResultType: [User].self) { users, error in
@@ -27,6 +28,7 @@ public extension Octokit {
         - parameter name: Name of the user
         - parameter completion: Callback for the outcome of the fetch.
     */
+    @discardableResult
     public func followers(_ session: RequestKitURLSession = URLSession.shared, name: String, completion: @escaping (_ response: Response<[User]>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = FollowRouter.readFollowers(name, configuration)
         return router.load(session, expectedResultType: [User].self) { users, error in
@@ -45,6 +47,7 @@ public extension Octokit {
         - parameter session: RequestKitURLSession, defaults to NSURLSession.sharedSession()
         - parameter completion: Callback for the outcome of the fetch.
     */
+    @discardableResult
     public func myFollowing(_ session: RequestKitURLSession = URLSession.shared, completion: @escaping (_ response: Response<[User]>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = FollowRouter.readAuthenticatedFollowing(configuration)
         return router.load(session, expectedResultType: [User].self) { users, error in
@@ -64,6 +67,7 @@ public extension Octokit {
         - parameter name: The name of the user
         - parameter completion: Callback for the outcome of the fetch.
     */
+    @discardableResult
     public func following(_ session: RequestKitURLSession = URLSession.shared, name: String, completion: @escaping (_ response: Response<[User]>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = FollowRouter.readFollowing(name, configuration)
         return router.load(session, expectedResultType: [User].self) { users, error in

--- a/OctoKit/Issue.swift
+++ b/OctoKit/Issue.swift
@@ -69,6 +69,7 @@ public extension Octokit {
      - parameter perPage: Number of issues per page. `100` by default.
      - parameter completion: Callback for the outcome of the fetch.
      */
+    @discardableResult
     public func myIssues(_ session: RequestKitURLSession = URLSession.shared, state: Openness = .Open, page: String = "1", perPage: String = "100", completion: @escaping (_ response: Response<[Issue]>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = IssueRouter.readAuthenticatedIssues(configuration, page, perPage, state)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Issue].self) { issues, error in
@@ -90,6 +91,7 @@ public extension Octokit {
      - parameter number: The number of the issue.
      - parameter completion: Callback for the outcome of the fetch.
      */
+    @discardableResult
     public func issue(_ session: RequestKitURLSession = URLSession.shared, owner: String, repository: String, number: Int, completion: @escaping (_ response: Response<Issue>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = IssueRouter.readIssue(configuration, owner, repository, number)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: Issue.self) { issue, error in
@@ -113,6 +115,7 @@ public extension Octokit {
      - parameter perPage: Number of issues per page. `100` by default.
      - parameter completion: Callback for the outcome of the fetch.
      */
+    @discardableResult
     public func issues(_ session: RequestKitURLSession = URLSession.shared, owner: String, repository: String, state: Openness = .Open, page: String = "1", perPage: String = "100", completion: @escaping (_ response: Response<[Issue]>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = IssueRouter.readIssues(configuration, owner, repository, page, perPage, state)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Issue].self) { issues, error in
@@ -136,6 +139,7 @@ public extension Octokit {
      - parameter assignee: The name of the user to assign the issue to. This parameter is ignored if the user lacks push access to the repository.
      - parameter completion: Callback for the issue that is created.
      */
+    @discardableResult
     public func postIssue(_ session: RequestKitURLSession = URLSession.shared, owner: String, repository: String, title: String, body: String? = nil, assignee: String? = nil, completion: @escaping (_ response: Response<Issue>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = IssueRouter.postIssue(configuration, owner, repository, title, body, assignee)
         return router.post(session, expectedResultType: Issue.self) { issue, error in
@@ -161,6 +165,7 @@ public extension Octokit {
      - parameter state: Whether the issue is open or closed.
      - parameter completion: Callback for the issue that is created.
      */
+    @discardableResult
     public func patchIssue(_ session: RequestKitURLSession = URLSession.shared, owner: String, repository: String, number: Int, title: String? = nil, body: String? = nil, assignee: String? = nil, state: Openness? = nil, completion: @escaping (_ response: Response<Issue>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = IssueRouter.patchIssue(configuration, owner, repository, number, title, body, assignee, state)
         return router.post(session, expectedResultType: Issue.self) { issue, error in

--- a/OctoKit/PullRequest.swift
+++ b/OctoKit/PullRequest.swift
@@ -68,6 +68,7 @@ public extension Octokit {
     - parameter number: The number of the PR to fetch.
     - parameter completion: Callback for the outcome of the fetch.
     */
+    @discardableResult
     public func pullRequest(_ session: RequestKitURLSession = URLSession.shared,
                             owner: String,
                             repository: String,
@@ -96,6 +97,7 @@ public extension Octokit {
     - parameter direction: The direction of the sort.
     - parameter completion: Callback for the outcome of the fetch.
     */
+    @discardableResult
     public func pullRequests(_ session: RequestKitURLSession = URLSession.shared,
                              owner: String,
                              repository: String,

--- a/OctoKit/Repositories.swift
+++ b/OctoKit/Repositories.swift
@@ -46,6 +46,7 @@ public extension Octokit {
         - parameter perPage: Number of repositories per page. `100` by default.
         - parameter completion: Callback for the outcome of the fetch.
     */
+    @discardableResult
     public func repositories(_ session: RequestKitURLSession = URLSession.shared, owner: String? = nil, page: String = "1", perPage: String = "100", completion: @escaping (_ response: Response<[Repository]>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = (owner != nil)
             ? RepositoryRouter.readRepositories(configuration, owner!, page, perPage)
@@ -68,6 +69,7 @@ public extension Octokit {
         - parameter name: The name of the repository to fetch.
         - parameter completion: Callback for the outcome of the fetch.
     */
+    @discardableResult
     public func repository(_ session: RequestKitURLSession = URLSession.shared, owner: String, name: String, completion: @escaping (_ response: Response<Repository>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = RepositoryRouter.readRepository(configuration, owner, name)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: Repository.self) { repo, error in

--- a/OctoKit/Stars.swift
+++ b/OctoKit/Stars.swift
@@ -9,6 +9,7 @@ public extension Octokit {
         - parameter name: The user who starred repositories.
         - parameter completion: Callback for the outcome of the fetch.
     */
+    @discardableResult
     public func stars(_ session: RequestKitURLSession = URLSession.shared, name: String, completion: @escaping (_ response: Response<[Repository]>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = StarsRouter.readStars(name, configuration)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Repository].self) { repos, error in
@@ -27,6 +28,7 @@ public extension Octokit {
         - parameter session: RequestKitURLSession, defaults to NSURLSession.sharedSession()
         - parameter completion: Callback for the outcome of the fetch.
     */
+    @discardableResult
     public func myStars(_ session: RequestKitURLSession = URLSession.shared, completion: @escaping (_ response: Response<[Repository]>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = StarsRouter.readAuthenticatedStars(configuration)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Repository].self) { repos, error in

--- a/OctoKit/User.swift
+++ b/OctoKit/User.swift
@@ -44,6 +44,7 @@ public extension Octokit {
         - parameter name: The name of the user or organization.
         - parameter completion: Callback for the outcome of the fetch.
     */
+    @discardableResult
     public func user(_ session: RequestKitURLSession = URLSession.shared, name: String, completion: @escaping (_ response: Response<User>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = UserRouter.readUser(name, self.configuration)
         return router.load(session, expectedResultType: User.self) { user, error in
@@ -62,6 +63,7 @@ public extension Octokit {
         - parameter session: RequestKitURLSession, defaults to NSURLSession.sharedSession()
         - parameter completion: Callback for the outcome of the fetch.
     */
+    @discardableResult
     public func me(_ session: RequestKitURLSession = URLSession.shared, completion: @escaping (_ response: Response<User>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = UserRouter.readAuthenticatedUser(self.configuration)
         return router.load(session, expectedResultType: User.self) { user, error in


### PR DESCRIPTION
👋 

Looking good so far. 👍 

Mainly so that we don't have to do things like this in Dangerfiles for danger-swift:

```swift
_ = danger.github.api.me { response in
    switch response {
    case .success(let user):
        message(user.name ?? "")
    case .failure:
        break
    }
}
```