### PR TITLE
Fixed issue of nil htmlURL

### DIFF
--- a/OctoKit/PullRequest.swift
+++ b/OctoKit/PullRequest.swift
@@ -41,6 +41,7 @@ open class PullRequest: Codable {
         case reviewCommentsURL = "review_comments_url"
         case commentsURL = "comments_url"
         case statusesURL = "statuses_url"
+        case htmlURL = "html_url"
         case number
         case state
         case title


### PR DESCRIPTION
The htmlURL of a pull request was always nil due to the incorrect mapping of the `Codable` conformance of the `PullRequest` object.

The JSON response always returned the attribute as `html_url`, but this was never mapped in the `PullRequest` object. 