### PR TITLE
Add labels parameter to postIssue

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ Octokit(config).issue(owner, repository: repo, number: number) { response in
 ### Open a new issue
 
 ```swift
-Octokit(config).postIssue("owner", repository: "repo", title: "Found a bug", body: "I'm having a problem with this.", assignee: "octocat") { response in
+Octokit(config).postIssue("owner", repository: "repo", title: "Found a bug", body: "I'm having a problem with this.", assignee: "octocat", labels: ["bug", "duplicate"]) { response in
     switch response {
     case .success(let issue):
         // do something with the issue


### PR DESCRIPTION
This adds a labels parameter to `postIssue`, which takes an array of `String`, defaulting to an empty array (so it should have no impact on existing method calls).

If the label doesn't exist in the repo, Github will create it for us.
If the user doesn't have push access to the repo, the labels will be ignored.

I've also updated the `postIssue` example in `README` to include the parameter.