### PR TITLE
Allow requestkit versions until next major

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["OctoKit"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/nerdishbynature/RequestKit.git", .exact("2.3.0")),
+        .package(url: "https://github.com/nerdishbynature/RequestKit.git", from: "2.3.0"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
👋 
I wanted to use the latest RequestKit release.
Given `RequestKit` releases looks be conformant to semver it makes sense IMO to allow all the versions until the next major, please let me know if you prefer me to use `exact("2.4.0")` instead