### PR TITLE
Fix capitalization in `enum Openness`

### DIFF
--- a/OctoKit/Issue.swift
+++ b/OctoKit/Issue.swift
@@ -7,9 +7,9 @@ import FoundationNetworking
 // MARK: model
 
 public enum Openness: String, Codable {
-    case Open = "open"
-    case Closed = "closed"
-    case All = "all"
+    case open = "open"
+    case closed = "closed"
+    case all = "all"
 }
 
 open class Issue: Codable {
@@ -90,7 +90,7 @@ public extension Octokit {
      - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func myIssues(_ session: RequestKitURLSession = URLSession.shared, state: Openness = .Open, page: String = "1", perPage: String = "100", completion: @escaping (_ response: Response<[Issue]>) -> Void) -> URLSessionDataTaskProtocol? {
+    func myIssues(_ session: RequestKitURLSession = URLSession.shared, state: Openness = .open, page: String = "1", perPage: String = "100", completion: @escaping (_ response: Response<[Issue]>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = IssueRouter.readAuthenticatedIssues(configuration, page, perPage, state)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Issue].self) { issues, error in
             if let error = error {
@@ -136,7 +136,7 @@ public extension Octokit {
      - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func issues(_ session: RequestKitURLSession = URLSession.shared, owner: String, repository: String, state: Openness = .Open, page: String = "1", perPage: String = "100", completion: @escaping (_ response: Response<[Issue]>) -> Void) -> URLSessionDataTaskProtocol? {
+    func issues(_ session: RequestKitURLSession = URLSession.shared, owner: String, repository: String, state: Openness = .open, page: String = "1", perPage: String = "100", completion: @escaping (_ response: Response<[Issue]>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = IssueRouter.readIssues(configuration, owner, repository, page, perPage, state)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Issue].self) { issues, error in
             if let error = error {

--- a/OctoKit/PullRequest.swift
+++ b/OctoKit/PullRequest.swift
@@ -109,7 +109,7 @@ public extension Octokit {
                              owner: String,
                              repository: String,
                              base: String? = nil,
-                             state: Openness = .Open,
+                             state: Openness = .open,
                              sort: SortType = .created,
                              direction: SortDirection = .desc,
                              completion: @escaping (_ response: Response<[PullRequest]>) -> Void) -> URLSessionDataTaskProtocol? {

--- a/Tests/OctoKitTests/IssueTests.swift
+++ b/Tests/OctoKitTests/IssueTests.swift
@@ -84,7 +84,7 @@ class IssueTests: XCTestCase {
         XCTAssertEqual(subject.number, 1347)
         XCTAssertEqual(subject.title, "Found a bug")
         XCTAssertEqual(subject.htmlURL, URL(string: "https://github.com/octocat/Hello-World/issues/1347"))
-        XCTAssertEqual(subject.state, Openness.Open)
+        XCTAssertEqual(subject.state, Openness.open)
         XCTAssertEqual(subject.locked, false)
     }
     
@@ -97,7 +97,7 @@ class IssueTests: XCTestCase {
         XCTAssertEqual(subject.number, 36)
         XCTAssertEqual(subject.title, "Add Request: Test File")
         XCTAssertEqual(subject.htmlURL, URL(string: "https://github.com/vincode-io/FeedCompass/issues/36"))
-        XCTAssertEqual(subject.state, Openness.Open)
+        XCTAssertEqual(subject.state, Openness.open)
         XCTAssertEqual(subject.locked, false)
     }
     

--- a/Tests/OctoKitTests/PullRequestTests.swift
+++ b/Tests/OctoKitTests/PullRequestTests.swift
@@ -38,7 +38,7 @@ class PullRequestTests: XCTestCase {
                 statusCode: 200
         )
 
-        let task = Octokit().pullRequests(session, owner: "octocat", repository: "Hello-World", base: "develop", state: Openness.Open) { response in
+        let task = Octokit().pullRequests(session, owner: "octocat", repository: "Hello-World", base: "develop", state: Openness.open) { response in
             switch response {
             case .success(let pullRequests):
                 XCTAssertEqual(pullRequests.count, 1)


### PR DESCRIPTION
The current capitalization does not match the de-facto convention of making enum cases lowercase.