### PR TITLE
Fix `swift test` invocations on macOS

### DIFF
--- a/Tests/OctoKitTests/TestHelper.swift
+++ b/Tests/OctoKitTests/TestHelper.swift
@@ -40,26 +40,17 @@ internal class Helper {
     }
     
     private class func jsonFilePath(resourceName: String) -> String {
-        #if os(Linux)
-        let currentDirectoryPath = FileManager.default.currentDirectoryPath
-        let path = currentDirectoryPath + "/Tests/OctoKitTests/" + resourceName + ".json"
-        #else
-        let bundle = Bundle(for: self)
-        let path = bundle.path(forResource: resourceName, ofType: "json")!
-        #endif
-        
-        return path
+        return URL(fileURLWithPath: #file)
+            .deletingLastPathComponent()
+            .appendingPathComponent("\(resourceName).json")
+            .path
     }
     
     private class func jsonFixturesFilePath(resourceName: String) -> String {
-        #if os(Linux)
-        let currentDirectoryPath = FileManager.default.currentDirectoryPath
-        let path = currentDirectoryPath + "/Tests/OctoKitTests/Fixtures/" + resourceName + ".json"
-        #else
-        let bundle = Bundle(path: "OctoKitTests/Fixtures")
-        let path = bundle!.path(forResource: resourceName, ofType: "json")!
-        #endif
-        
-        return path
+        return URL(fileURLWithPath: #file)
+            .deletingLastPathComponent()
+            .appendingPathComponent("Fixtures")
+            .appendingPathComponent("\(resourceName).json")
+            .path
     }
 }


### PR DESCRIPTION
Currently, when opening `Package.swift` instead of the project file in Xcode, or when running `swift test` from command-line on macOS, the tests fail. This is caused by the lack of support for test bundle resources in SwiftPM. This can be easily fixed by inferring the test file path from the `#file` value. Additionally, this behaviour is cross-platform and doesn't require special handling on Linux.