### PR TITLE
Add base and head branch refs to PullRequest model

### DIFF
--- a/OctoKit/PullRequest.swift
+++ b/OctoKit/PullRequest.swift
@@ -34,6 +34,9 @@ open class PullRequest: Codable {
     open var number: Int
     open var state: Openness?
     open var labels: [Label]?
+
+    open var head: PullRequest.Branch?
+    open var base: PullRequest.Branch?
     
     enum CodingKeys: String, CodingKey {
         case id
@@ -59,9 +62,18 @@ open class PullRequest: Codable {
         case createdAt = "created_at"
         case updatedAt = "updated_at"
         case mergedAt = "merged_at"
+        case head
+        case base
+    }
+
+    open class Branch: Codable {
+        open var label: String?
+        open var ref: String?
+        open var sha: String?
+        open var user: User?
+        open var repo: Repository?
     }
 }
-
 
 // MARK: Request
 

--- a/Tests/OctoKitTests/PullRequestTests.swift
+++ b/Tests/OctoKitTests/PullRequestTests.swift
@@ -23,6 +23,18 @@ class PullRequestTests: XCTestCase {
                 XCTAssertEqual(pullRequests.body, "Please pull these awesome changes")
                 XCTAssertEqual(pullRequests.labels?.count, 1)
                 XCTAssertEqual(pullRequests.user?.login, "octocat")
+
+                XCTAssertEqual(pullRequests.base?.label, "master")
+                XCTAssertEqual(pullRequests.base?.ref, "master")
+                XCTAssertEqual(pullRequests.base?.sha, "6dcb09b5b57875f334f61aebed695e2e4193db5e")
+                XCTAssertEqual(pullRequests.base?.user?.login, "octocat")
+                XCTAssertEqual(pullRequests.base?.repo?.name, "Hello-World")
+
+                XCTAssertEqual(pullRequests.head?.label, "new-topic")
+                XCTAssertEqual(pullRequests.head?.ref, "new-topic")
+                XCTAssertEqual(pullRequests.head?.sha, "6dcb09b5b57875f334f61aebed695e2e4193db5e")
+                XCTAssertEqual(pullRequests.head?.user?.login, "octocat")
+                XCTAssertEqual(pullRequests.head?.repo?.name, "Hello-World")
             case .failure(let error):
                 XCTAssertNil(error)
             }
@@ -46,6 +58,18 @@ class PullRequestTests: XCTestCase {
                 XCTAssertEqual(pullRequests.first?.body, "Please pull these awesome changes")
                 XCTAssertEqual(pullRequests.first?.labels?.count, 1)
                 XCTAssertEqual(pullRequests.first?.user?.login, "octocat")
+
+                XCTAssertEqual(pullRequests.first?.base?.label, "master")
+                XCTAssertEqual(pullRequests.first?.base?.ref, "master")
+                XCTAssertEqual(pullRequests.first?.base?.sha, "6dcb09b5b57875f334f61aebed695e2e4193db5e")
+                XCTAssertEqual(pullRequests.first?.base?.user?.login, "octocat")
+                XCTAssertEqual(pullRequests.first?.base?.repo?.name, "Hello-World")
+
+                XCTAssertEqual(pullRequests.first?.head?.label, "new-topic")
+                XCTAssertEqual(pullRequests.first?.head?.ref, "new-topic")
+                XCTAssertEqual(pullRequests.first?.head?.sha, "6dcb09b5b57875f334f61aebed695e2e4193db5e")
+                XCTAssertEqual(pullRequests.first?.head?.user?.login, "octocat")
+                XCTAssertEqual(pullRequests.first?.head?.repo?.name, "Hello-World")
             case .failure(let error):
                 XCTAssertNil(error)
             }


### PR DESCRIPTION
Just adds two new properties to `PullRequest`.