### PR TITLE
Use docker for Linux builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,10 +37,8 @@ jobs:
   spm:
     name: Test with SPM
     runs-on: ubuntu-latest
+    container: swift:5.3-focal
     steps:
       - uses: actions/checkout@v2
-      - uses: sersoft-gmbh/SwiftyActions@v1
-        with:
-          release-version: 5.3.2
       - name: SPM Test
         run: swift test


### PR DESCRIPTION
Builds were failing on Linux so I converted it to use the official Docker Image instead of the first GitHub Action I found googling.