### PR TITLE
Use RequestKit 3 and use Result instead of Response

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,9 +11,9 @@ on:
 jobs:
   macOS:
     name: Test macOS
-    runs-on: macOS-latest
+    runs-on: macOS-11
     env:
-      DEVELOPER_DIR: /Applications/Xcode_12.3.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_13.0.app/Contents/Developer
     strategy:
       matrix:
         include:
@@ -37,7 +37,7 @@ jobs:
   spm:
     name: Test with SPM
     runs-on: ubuntu-latest
-    container: swift:5.3-focal
+    container: swift:5.5-focal
     steps:
       - uses: actions/checkout@v2
       - name: SPM Test

--- a/OctoKit/Follow.swift
+++ b/OctoKit/Follow.swift
@@ -11,14 +11,14 @@ public extension Octokit {
          - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func myFollowers(_ session: RequestKitURLSession = URLSession.shared, completion: @escaping (_ response: Response<[User]>) -> Void) -> URLSessionDataTaskProtocol? {
+    func myFollowers(_ session: RequestKitURLSession = URLSession.shared, completion: @escaping (_ response: Result<[User], Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = FollowRouter.readAuthenticatedFollowers(configuration)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [User].self) { users, error in
             if let error = error {
-                completion(Response.failure(error))
+                completion(.failure(error))
             } else {
                 if let users = users {
-                    completion(Response.success(users))
+                    completion(.success(users))
                 }
             }
         }
@@ -31,14 +31,14 @@ public extension Octokit {
          - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func followers(_ session: RequestKitURLSession = URLSession.shared, name: String, completion: @escaping (_ response: Response<[User]>) -> Void) -> URLSessionDataTaskProtocol? {
+    func followers(_ session: RequestKitURLSession = URLSession.shared, name: String, completion: @escaping (_ response: Result<[User], Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = FollowRouter.readFollowers(name, configuration)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [User].self) { users, error in
             if let error = error {
-                completion(Response.failure(error))
+                completion(.failure(error))
             } else {
                 if let users = users {
-                    completion(Response.success(users))
+                    completion(.success(users))
                 }
             }
         }
@@ -50,11 +50,11 @@ public extension Octokit {
          - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func myFollowing(_ session: RequestKitURLSession = URLSession.shared, completion: @escaping (_ response: Response<[User]>) -> Void) -> URLSessionDataTaskProtocol? {
+    func myFollowing(_ session: RequestKitURLSession = URLSession.shared, completion: @escaping (_ response: Result<[User], Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = FollowRouter.readAuthenticatedFollowing(configuration)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [User].self) { users, error in
             if let error = error {
-                completion(Response.failure(error))
+                completion(.failure(error))
             } else {
                 if let users = users {
                     completion(.success(users))
@@ -70,14 +70,14 @@ public extension Octokit {
          - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func following(_ session: RequestKitURLSession = URLSession.shared, name: String, completion: @escaping (_ response: Response<[User]>) -> Void) -> URLSessionDataTaskProtocol? {
+    func following(_ session: RequestKitURLSession = URLSession.shared, name: String, completion: @escaping (_ response: Result<[User], Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = FollowRouter.readFollowing(name, configuration)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [User].self) { users, error in
             if let error = error {
-                completion(Response.failure(error))
+                completion(.failure(error))
             } else {
                 if let users = users {
-                    completion(Response.success(users))
+                    completion(.success(users))
                 }
             }
         }

--- a/OctoKit/Gist.swift
+++ b/OctoKit/Gist.swift
@@ -56,15 +56,15 @@ public extension Octokit {
      */
     @discardableResult
     func myGists(_ session: RequestKitURLSession = URLSession.shared, page: String = "1", perPage: String = "100",
-                 completion: @escaping (_ response: Response<[Gist]>) -> Void) -> URLSessionDataTaskProtocol?
+                 completion: @escaping (_ response: Result<[Gist], Error>) -> Void) -> URLSessionDataTaskProtocol?
     {
         let router = GistRouter.readAuthenticatedGists(configuration, page, perPage)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Gist].self) { gists, error in
             if let error = error {
-                completion(Response.failure(error))
+                completion(.failure(error))
             } else {
                 if let gists = gists {
-                    completion(Response.success(gists))
+                    completion(.success(gists))
                 }
             }
         }
@@ -80,15 +80,15 @@ public extension Octokit {
      */
     @discardableResult
     func gists(_ session: RequestKitURLSession = URLSession.shared, owner: String, page: String = "1", perPage: String = "100",
-               completion: @escaping (_ response: Response<[Gist]>) -> Void) -> URLSessionDataTaskProtocol?
+               completion: @escaping (_ response: Result<[Gist], Error>) -> Void) -> URLSessionDataTaskProtocol?
     {
         let router = GistRouter.readGists(configuration, owner, page, perPage)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Gist].self) { gists, error in
             if let error = error {
-                completion(Response.failure(error))
+                completion(.failure(error))
             } else {
                 if let gists = gists {
-                    completion(Response.success(gists))
+                    completion(.success(gists))
                 }
             }
         }
@@ -101,14 +101,14 @@ public extension Octokit {
      - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func gist(_ session: RequestKitURLSession = URLSession.shared, id: String, completion: @escaping (_ response: Response<Gist>) -> Void) -> URLSessionDataTaskProtocol? {
+    func gist(_ session: RequestKitURLSession = URLSession.shared, id: String, completion: @escaping (_ response: Result<Gist, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = GistRouter.readGist(configuration, id)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: Gist.self) { gist, error in
             if let error = error {
-                completion(Response.failure(error))
+                completion(.failure(error))
             } else {
                 if let gist = gist {
-                    completion(Response.success(gist))
+                    completion(.success(gist))
                 }
             }
         }
@@ -129,17 +129,17 @@ public extension Octokit {
                       filename: String,
                       fileContent: String,
                       publicAccess: Bool,
-                      completion: @escaping (_ response: Response<Gist>) -> Void) -> URLSessionDataTaskProtocol?
+                      completion: @escaping (_ response: Result<Gist, Error>) -> Void) -> URLSessionDataTaskProtocol?
     {
         let router = GistRouter.postGistFile(configuration, description, filename, fileContent, publicAccess)
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(Time.rfc3339DateFormatter)
         return router.post(session, decoder: decoder, expectedResultType: Gist.self) { gist, error in
             if let error = error {
-                completion(Response.failure(error))
+                completion(.failure(error))
             } else {
                 if let gist = gist {
-                    completion(Response.success(gist))
+                    completion(.success(gist))
                 }
             }
         }
@@ -160,17 +160,17 @@ public extension Octokit {
                        description: String,
                        filename: String,
                        fileContent: String,
-                       completion: @escaping (_ response: Response<Gist>) -> Void) -> URLSessionDataTaskProtocol?
+                       completion: @escaping (_ response: Result<Gist, Error>) -> Void) -> URLSessionDataTaskProtocol?
     {
         let router = GistRouter.patchGistFile(configuration, id, description, filename, fileContent)
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(Time.rfc3339DateFormatter)
         return router.post(session, decoder: decoder, expectedResultType: Gist.self) { gist, error in
             if let error = error {
-                completion(Response.failure(error))
+                completion(.failure(error))
             } else {
                 if let gist = gist {
-                    completion(Response.success(gist))
+                    completion(.success(gist))
                 }
             }
         }

--- a/OctoKit/Issue.swift
+++ b/OctoKit/Issue.swift
@@ -94,15 +94,15 @@ public extension Octokit {
                   state: Openness = .open,
                   page: String = "1",
                   perPage: String = "100",
-                  completion: @escaping (_ response: Response<[Issue]>) -> Void) -> URLSessionDataTaskProtocol?
+                  completion: @escaping (_ response: Result<[Issue], Error>) -> Void) -> URLSessionDataTaskProtocol?
     {
         let router = IssueRouter.readAuthenticatedIssues(configuration, page, perPage, state)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Issue].self) { issues, error in
             if let error = error {
-                completion(Response.failure(error))
+                completion(.failure(error))
             } else {
                 if let issues = issues {
-                    completion(Response.success(issues))
+                    completion(.success(issues))
                 }
             }
         }
@@ -118,15 +118,15 @@ public extension Octokit {
      */
     @discardableResult
     func issue(_ session: RequestKitURLSession = URLSession.shared, owner: String, repository: String, number: Int,
-               completion: @escaping (_ response: Response<Issue>) -> Void) -> URLSessionDataTaskProtocol?
+               completion: @escaping (_ response: Result<Issue, Error>) -> Void) -> URLSessionDataTaskProtocol?
     {
         let router = IssueRouter.readIssue(configuration, owner, repository, number)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: Issue.self) { issue, error in
             if let error = error {
-                completion(Response.failure(error))
+                completion(.failure(error))
             } else {
                 if let issue = issue {
-                    completion(Response.success(issue))
+                    completion(.success(issue))
                 }
             }
         }
@@ -149,15 +149,15 @@ public extension Octokit {
                 state: Openness = .open,
                 page: String = "1",
                 perPage: String = "100",
-                completion: @escaping (_ response: Response<[Issue]>) -> Void) -> URLSessionDataTaskProtocol?
+                completion: @escaping (_ response: Result<[Issue], Error>) -> Void) -> URLSessionDataTaskProtocol?
     {
         let router = IssueRouter.readIssues(configuration, owner, repository, page, perPage, state)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Issue].self) { issues, error in
             if let error = error {
-                completion(Response.failure(error))
+                completion(.failure(error))
             } else {
                 if let issues = issues {
-                    completion(Response.success(issues))
+                    completion(.success(issues))
                 }
             }
         }
@@ -182,17 +182,17 @@ public extension Octokit {
                    body: String? = nil,
                    assignee: String? = nil,
                    labels: [String] = [],
-                   completion: @escaping (_ response: Response<Issue>) -> Void) -> URLSessionDataTaskProtocol?
+                   completion: @escaping (_ response: Result<Issue, Error>) -> Void) -> URLSessionDataTaskProtocol?
     {
         let router = IssueRouter.postIssue(configuration, owner, repository, title, body, assignee, labels)
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(Time.rfc3339DateFormatter)
         return router.post(session, decoder: decoder, expectedResultType: Issue.self) { issue, error in
             if let error = error {
-                completion(Response.failure(error))
+                completion(.failure(error))
             } else {
                 if let issue = issue {
-                    completion(Response.success(issue))
+                    completion(.success(issue))
                 }
             }
         }
@@ -219,15 +219,15 @@ public extension Octokit {
                     body: String? = nil,
                     assignee: String? = nil,
                     state: Openness? = nil,
-                    completion: @escaping (_ response: Response<Issue>) -> Void) -> URLSessionDataTaskProtocol?
+                    completion: @escaping (_ response: Result<Issue, Error>) -> Void) -> URLSessionDataTaskProtocol?
     {
         let router = IssueRouter.patchIssue(configuration, owner, repository, number, title, body, assignee, state)
         return router.post(session, expectedResultType: Issue.self) { issue, error in
             if let error = error {
-                completion(Response.failure(error))
+                completion(.failure(error))
             } else {
                 if let issue = issue {
-                    completion(Response.success(issue))
+                    completion(.success(issue))
                 }
             }
         }
@@ -243,17 +243,17 @@ public extension Octokit {
     ///   - completion: Callback for the comment that is created.
     @discardableResult
     func commentIssue(_ session: RequestKitURLSession = URLSession.shared, owner: String, repository: String, number: Int, body: String,
-                      completion: @escaping (_ response: Response<Comment>) -> Void) -> URLSessionDataTaskProtocol?
+                      completion: @escaping (_ response: Result<Comment, Error>) -> Void) -> URLSessionDataTaskProtocol?
     {
         let router = IssueRouter.commentIssue(configuration, owner, repository, number, body)
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(Time.rfc3339DateFormatter)
         return router.post(session, decoder: decoder, expectedResultType: Comment.self) { issue, error in
             if let error = error {
-                completion(Response.failure(error))
+                completion(.failure(error))
             } else {
                 if let issue = issue {
-                    completion(Response.success(issue))
+                    completion(.success(issue))
                 }
             }
         }
@@ -275,15 +275,15 @@ public extension Octokit {
                        number: Int,
                        page: String = "1",
                        perPage: String = "100",
-                       completion: @escaping (_ response: Response<[Comment]>) -> Void) -> URLSessionDataTaskProtocol?
+                       completion: @escaping (_ response: Result<[Comment], Error>) -> Void) -> URLSessionDataTaskProtocol?
     {
         let router = IssueRouter.readIssueComments(configuration, owner, repository, number, page, perPage)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Comment].self) { comments, error in
             if let error = error {
-                completion(Response.failure(error))
+                completion(.failure(error))
             } else {
                 if let comments = comments {
-                    completion(Response.success(comments))
+                    completion(.success(comments))
                 }
             }
         }
@@ -299,17 +299,17 @@ public extension Octokit {
     ///   - completion: Callback for the comment that is created.
     @discardableResult
     func patchIssueComment(_ session: RequestKitURLSession = URLSession.shared, owner: String, repository: String, number: Int, body: String,
-                           completion: @escaping (_ response: Response<Comment>) -> Void) -> URLSessionDataTaskProtocol?
+                           completion: @escaping (_ response: Result<Comment, Error>) -> Void) -> URLSessionDataTaskProtocol?
     {
         let router = IssueRouter.patchIssueComment(configuration, owner, repository, number, body)
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(Time.rfc3339DateFormatter)
         return router.post(session, decoder: decoder, expectedResultType: Comment.self) { issue, error in
             if let error = error {
-                completion(Response.failure(error))
+                completion(.failure(error))
             } else {
                 if let issue = issue {
-                    completion(Response.success(issue))
+                    completion(.success(issue))
                 }
             }
         }

--- a/OctoKit/Label.swift
+++ b/OctoKit/Label.swift
@@ -23,15 +23,15 @@ public extension Octokit {
      */
     @discardableResult
     func label(_ session: RequestKitURLSession = URLSession.shared, owner: String, repository: String, name: String,
-               completion: @escaping (_ response: Response<Label>) -> Void) -> URLSessionDataTaskProtocol?
+               completion: @escaping (_ response: Result<Label, Error>) -> Void) -> URLSessionDataTaskProtocol?
     {
         let router = LabelRouter.readLabel(configuration, owner, repository, name)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: Label.self) { label, error in
             if let error = error {
-                completion(Response.failure(error))
+                completion(.failure(error))
             } else {
                 if let label = label {
-                    completion(Response.success(label))
+                    completion(.success(label))
                 }
             }
         }
@@ -52,15 +52,15 @@ public extension Octokit {
                 repository: String,
                 page: String = "1",
                 perPage: String = "100",
-                completion: @escaping (_ response: Response<[Label]>) -> Void) -> URLSessionDataTaskProtocol?
+                completion: @escaping (_ response: Result<[Label], Error>) -> Void) -> URLSessionDataTaskProtocol?
     {
         let router = LabelRouter.readLabels(configuration, owner, repository, page, perPage)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Label].self) { labels, error in
             if let error = error {
-                completion(Response.failure(error))
+                completion(.failure(error))
             } else {
                 if let labels = labels {
-                    completion(Response.success(labels))
+                    completion(.success(labels))
                 }
             }
         }
@@ -77,15 +77,15 @@ public extension Octokit {
      */
     @discardableResult
     func postLabel(_ session: RequestKitURLSession = URLSession.shared, owner: String, repository: String, name: String, color: String,
-                   completion: @escaping (_ response: Response<Label>) -> Void) -> URLSessionDataTaskProtocol?
+                   completion: @escaping (_ response: Result<Label, Error>) -> Void) -> URLSessionDataTaskProtocol?
     {
         let router = LabelRouter.createLabel(configuration, owner, repository, name, color)
         return router.post(session, expectedResultType: Label.self) { label, error in
             if let error = error {
-                completion(Response.failure(error))
+                completion(.failure(error))
             } else {
                 if let label = label {
-                    completion(Response.success(label))
+                    completion(.success(label))
                 }
             }
         }

--- a/OctoKit/NotificationThread.swift
+++ b/OctoKit/NotificationThread.swift
@@ -91,15 +91,15 @@ public extension Octokit {
                          participating: Bool = false,
                          page: String = "1",
                          perPage: String = "100",
-                         completion: @escaping (_ response: Response<[NotificationThread]>) -> Void) -> URLSessionDataTaskProtocol?
+                         completion: @escaping (_ response: Result<[NotificationThread], Error>) -> Void) -> URLSessionDataTaskProtocol?
     {
         let router = NotificationRouter.readNotifications(configuration, all, participating, page, perPage)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [NotificationThread].self) { notifications, error in
             if let error = error {
-                completion(Response.failure(error))
+                completion(.failure(error))
             } else {
                 if let notifications = notifications {
-                    completion(Response.success(notifications))
+                    completion(.success(notifications))
                 }
             }
         }
@@ -128,15 +128,15 @@ public extension Octokit {
      */
     @discardableResult
     func getNotificationThread(_ session: RequestKitURLSession = URLSession.shared, threadId: String,
-                               completion: @escaping (_ response: Response<NotificationThread>) -> Void) -> URLSessionDataTaskProtocol?
+                               completion: @escaping (_ response: Result<NotificationThread, Error>) -> Void) -> URLSessionDataTaskProtocol?
     {
         let router = NotificationRouter.getNotificationThread(configuration, threadId)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: NotificationThread.self) { notification, error in
             if let error = error {
-                completion(Response.failure(error))
+                completion(.failure(error))
             } else {
                 if let notification = notification {
-                    completion(Response.success(notification))
+                    completion(.success(notification))
                 }
             }
         }
@@ -150,15 +150,15 @@ public extension Octokit {
       */
     @discardableResult
     func getThreadSubscription(_ session: RequestKitURLSession = URLSession.shared, threadId: String,
-                               completion: @escaping (_ response: Response<ThreadSubscription>) -> Void) -> URLSessionDataTaskProtocol?
+                               completion: @escaping (_ response: Result<ThreadSubscription, Error>) -> Void) -> URLSessionDataTaskProtocol?
     {
         let router = NotificationRouter.getThreadSubscription(configuration, threadId)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: ThreadSubscription.self) { thread, error in
             if let error = error {
-                completion(Response.failure(error))
+                completion(.failure(error))
             } else {
                 if let thread = thread {
-                    completion(Response.success(thread))
+                    completion(.success(thread))
                 }
             }
         }
@@ -173,15 +173,15 @@ public extension Octokit {
      */
     @discardableResult
     func setThreadSubscription(_ session: RequestKitURLSession = URLSession.shared, threadId: String, ignored: Bool = false,
-                               completion: @escaping (_ response: Response<ThreadSubscription>) -> Void) -> URLSessionDataTaskProtocol?
+                               completion: @escaping (_ response: Result<ThreadSubscription, Error>) -> Void) -> URLSessionDataTaskProtocol?
     {
         let router = NotificationRouter.setThreadSubscription(configuration, threadId, ignored)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: ThreadSubscription.self) { thread, error in
             if let error = error {
-                completion(Response.failure(error))
+                completion(.failure(error))
             } else {
                 if let thread = thread {
-                    completion(Response.success(thread))
+                    completion(.success(thread))
                 }
             }
         }
@@ -222,15 +222,15 @@ public extension Octokit {
                                      before: String? = nil,
                                      page: String = "1",
                                      perPage: String = "100",
-                                     completion: @escaping (_ response: Response<[NotificationThread]>) -> Void) -> URLSessionDataTaskProtocol?
+                                     completion: @escaping (_ response: Result<[NotificationThread], Error>) -> Void) -> URLSessionDataTaskProtocol?
     {
         let router = NotificationRouter.listRepositoryNotifications(configuration, owner, repository, all, participating, since, before, perPage, page)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [NotificationThread].self) { notifications, error in
             if let error = error {
-                completion(Response.failure(error))
+                completion(.failure(error))
             } else {
                 if let notifications = notifications {
-                    completion(Response.success(notifications))
+                    completion(.success(notifications))
                 }
             }
         }

--- a/OctoKit/PublicKey.swift
+++ b/OctoKit/PublicKey.swift
@@ -8,15 +8,15 @@ import FoundationNetworking
 
 public extension Octokit {
     func postPublicKey(_ session: RequestKitURLSession = URLSession.shared, publicKey: String, title: String,
-                       completion: @escaping (_ response: Response<String>) -> Void) -> URLSessionDataTaskProtocol?
+                       completion: @escaping (_ response: Result<String, Error>) -> Void) -> URLSessionDataTaskProtocol?
     {
         let router = PublicKeyRouter.postPublicKey(publicKey, title, configuration)
         return router.postJSON(session, expectedResultType: [String: AnyObject].self) { json, error in
             if let error = error {
-                completion(Response.failure(error))
+                completion(.failure(error))
             } else {
                 if let _ = json {
-                    completion(Response.success(publicKey))
+                    completion(.success(publicKey))
                 }
             }
         }

--- a/OctoKit/PullRequest.swift
+++ b/OctoKit/PullRequest.swift
@@ -96,15 +96,15 @@ public extension Octokit {
                      owner: String,
                      repository: String,
                      number: Int,
-                     completion: @escaping (_ response: Response<PullRequest>) -> Void) -> URLSessionDataTaskProtocol?
+                     completion: @escaping (_ response: Result<PullRequest, Error>) -> Void) -> URLSessionDataTaskProtocol?
     {
         let router = PullRequestRouter.readPullRequest(configuration, owner, repository, "\(number)")
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: PullRequest.self) { pullRequest, error in
             if let error = error {
-                completion(Response.failure(error))
+                completion(.failure(error))
             } else {
                 if let pullRequest = pullRequest {
-                    completion(Response.success(pullRequest))
+                    completion(.success(pullRequest))
                 }
             }
         }
@@ -130,15 +130,15 @@ public extension Octokit {
                       state: Openness = .open,
                       sort: SortType = .created,
                       direction: SortDirection = .desc,
-                      completion: @escaping (_ response: Response<[PullRequest]>) -> Void) -> URLSessionDataTaskProtocol?
+                      completion: @escaping (_ response: Result<[PullRequest], Error>) -> Void) -> URLSessionDataTaskProtocol?
     {
         let router = PullRequestRouter.readPullRequests(configuration, owner, repository, base, head, state, sort, direction)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [PullRequest].self) { pullRequests, error in
             if let error = error {
-                completion(Response.failure(error))
+                completion(.failure(error))
             } else {
                 if let pullRequests = pullRequests {
-                    completion(Response.success(pullRequests))
+                    completion(.success(pullRequests))
                 }
             }
         }

--- a/OctoKit/Releases.swift
+++ b/OctoKit/Releases.swift
@@ -58,15 +58,15 @@ public extension Octokit {
     ///   - completion: Callback for the outcome of the fetch.
     @discardableResult
     func listReleases(_ session: RequestKitURLSession = URLSession.shared, owner: String, repository: String,
-                      completion: @escaping (_ response: Response<[Release]>) -> Void) -> URLSessionDataTaskProtocol?
+                      completion: @escaping (_ response: Result<[Release], Error>) -> Void) -> URLSessionDataTaskProtocol?
     {
         let router = ReleaseRouter.listReleases(configuration, owner, repository)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Release].self) { releases, error in
             if let error = error {
-                completion(Response.failure(error))
+                completion(.failure(error))
             } else {
                 if let releases = releases {
-                    completion(Response.success(releases))
+                    completion(.success(releases))
                 }
             }
         }
@@ -94,7 +94,7 @@ public extension Octokit {
                      body: String? = nil,
                      prerelease: Bool = false,
                      draft: Bool = false,
-                     completion: @escaping (_ response: Response<Release>) -> Void) -> URLSessionDataTaskProtocol?
+                     completion: @escaping (_ response: Result<Release, Error>) -> Void) -> URLSessionDataTaskProtocol?
     {
         let router = ReleaseRouter.postRelease(configuration, owner, repository, tagName, targetCommitish, name, body, prerelease, draft)
         let decoder = JSONDecoder()
@@ -102,10 +102,10 @@ public extension Octokit {
 
         return router.post(session, decoder: decoder, expectedResultType: Release.self) { issue, error in
             if let error = error {
-                completion(Response.failure(error))
+                completion(.failure(error))
             } else {
                 if let issue = issue {
-                    completion(Response.success(issue))
+                    completion(.success(issue))
                 }
             }
         }

--- a/OctoKit/Repositories.swift
+++ b/OctoKit/Repositories.swift
@@ -56,18 +56,18 @@ public extension Octokit {
                       owner: String? = nil,
                       page: String = "1",
                       perPage: String = "100",
-                      completion: @escaping (_ response: Response<[Repository]>) -> Void) -> URLSessionDataTaskProtocol?
+                      completion: @escaping (_ response: Result<[Repository], Error>) -> Void) -> URLSessionDataTaskProtocol?
     {
         let router = (owner != nil)
             ? RepositoryRouter.readRepositories(configuration, owner!, page, perPage)
             : RepositoryRouter.readAuthenticatedRepositories(configuration, page, perPage)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Repository].self) { repos, error in
             if let error = error {
-                completion(Response.failure(error))
+                completion(.failure(error))
             }
 
             if let repos = repos {
-                completion(Response.success(repos))
+                completion(.success(repos))
             }
         }
     }
@@ -80,14 +80,16 @@ public extension Octokit {
          - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func repository(_ session: RequestKitURLSession = URLSession.shared, owner: String, name: String, completion: @escaping (_ response: Response<Repository>) -> Void) -> URLSessionDataTaskProtocol? {
+    func repository(_ session: RequestKitURLSession = URLSession.shared, owner: String, name: String,
+                    completion: @escaping (_ response: Result<Repository, Error>) -> Void) -> URLSessionDataTaskProtocol?
+    {
         let router = RepositoryRouter.readRepository(configuration, owner, name)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: Repository.self) { repo, error in
             if let error = error {
-                completion(Response.failure(error))
+                completion(.failure(error))
             } else {
                 if let repo = repo {
-                    completion(Response.success(repo))
+                    completion(.success(repo))
                 }
             }
         }

--- a/OctoKit/Review.swift
+++ b/OctoKit/Review.swift
@@ -40,15 +40,15 @@ public extension Octokit {
                      owner: String,
                      repository: String,
                      pullRequestNumber: Int,
-                     completion: @escaping (_ response: Response<[Review]>) -> Void) -> URLSessionDataTaskProtocol?
+                     completion: @escaping (_ response: Result<[Review], Error>) -> Void) -> URLSessionDataTaskProtocol?
     {
         let router = ReviewsRouter.listReviews(configuration, owner, repository, pullRequestNumber)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Review].self) { pullRequests, error in
             if let error = error {
-                completion(Response.failure(error))
+                completion(.failure(error))
             } else {
                 if let pullRequests = pullRequests {
-                    completion(Response.success(pullRequests))
+                    completion(.success(pullRequests))
                 }
             }
         }

--- a/OctoKit/Stars.swift
+++ b/OctoKit/Stars.swift
@@ -12,14 +12,14 @@ public extension Octokit {
          - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func stars(_ session: RequestKitURLSession = URLSession.shared, name: String, completion: @escaping (_ response: Response<[Repository]>) -> Void) -> URLSessionDataTaskProtocol? {
+    func stars(_ session: RequestKitURLSession = URLSession.shared, name: String, completion: @escaping (_ response: Result<[Repository], Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = StarsRouter.readStars(name, configuration)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Repository].self) { repos, error in
             if let error = error {
-                completion(Response.failure(error))
+                completion(.failure(error))
             } else {
                 if let repos = repos {
-                    completion(Response.success(repos))
+                    completion(.success(repos))
                 }
             }
         }
@@ -31,14 +31,14 @@ public extension Octokit {
          - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func myStars(_ session: RequestKitURLSession = URLSession.shared, completion: @escaping (_ response: Response<[Repository]>) -> Void) -> URLSessionDataTaskProtocol? {
+    func myStars(_ session: RequestKitURLSession = URLSession.shared, completion: @escaping (_ response: Result<[Repository], Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = StarsRouter.readAuthenticatedStars(configuration)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Repository].self) { repos, error in
             if let error = error {
-                completion(Response.failure(error))
+                completion(.failure(error))
             } else {
                 if let repos = repos {
-                    completion(Response.success(repos))
+                    completion(.success(repos))
                 }
             }
         }

--- a/OctoKit/Statuses.swift
+++ b/OctoKit/Statuses.swift
@@ -65,7 +65,7 @@ public extension Octokit {
                             targetURL: String? = nil,
                             description: String? = nil,
                             context: String? = nil,
-                            completion: @escaping (_ response: Response<Status>) -> Void) -> URLSessionDataTaskProtocol?
+                            completion: @escaping (_ response: Result<Status, Error>) -> Void) -> URLSessionDataTaskProtocol?
     {
         let router = StatusesRouter.createCommitStatus(configuration, owner: owner, repo: repository, sha: sha, state: state, targetURL: targetURL, description: description, context: context)
         let decoder = JSONDecoder()
@@ -94,7 +94,7 @@ public extension Octokit {
                             owner: String,
                             repository: String,
                             ref: String,
-                            completion: @escaping (_ response: Response<[Status]>) -> Void) -> URLSessionDataTaskProtocol?
+                            completion: @escaping (_ response: Result<[Status], Error>) -> Void) -> URLSessionDataTaskProtocol?
     {
         let router = StatusesRouter.listCommitStatuses(configuration, owner: owner, repo: repository, ref: ref)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Status].self) { statuses, error in

--- a/OctoKit/User.swift
+++ b/OctoKit/User.swift
@@ -98,14 +98,14 @@ public extension Octokit {
          - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func user(_ session: RequestKitURLSession = URLSession.shared, name: String, completion: @escaping (_ response: Response<User>) -> Void) -> URLSessionDataTaskProtocol? {
+    func user(_ session: RequestKitURLSession = URLSession.shared, name: String, completion: @escaping (_ response: Result<User, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = UserRouter.readUser(name, configuration)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: User.self) { user, error in
             if let error = error {
-                completion(Response.failure(error))
+                completion(.failure(error))
             } else {
                 if let user = user {
-                    completion(Response.success(user))
+                    completion(.success(user))
                 }
             }
         }
@@ -117,14 +117,14 @@ public extension Octokit {
          - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func me(_ session: RequestKitURLSession = URLSession.shared, completion: @escaping (_ response: Response<User>) -> Void) -> URLSessionDataTaskProtocol? {
+    func me(_ session: RequestKitURLSession = URLSession.shared, completion: @escaping (_ response: Result<User, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = UserRouter.readAuthenticatedUser(configuration)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: User.self) { user, error in
             if let error = error {
-                completion(Response.failure(error))
+                completion(.failure(error))
             } else {
                 if let user = user {
-                    completion(Response.success(user))
+                    completion(.success(user))
                 }
             }
         }

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/nerdishbynature/RequestKit.git",
         "state": {
           "branch": null,
-          "revision": "fd5e9e99aada7432170366c9e95967011ce13bad",
-          "version": "2.4.0"
+          "revision": "cfc435be3eef8f1e7507ac81c0ac41d83fc199e6",
+          "version": "3.0.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["OctoKit"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/nerdishbynature/RequestKit.git", from: "2.3.0"),
+        .package(url: "https://github.com/nerdishbynature/RequestKit.git", from: "3.0.0"),
     ],
     targets: [
         .target(

--- a/Tests/OctoKitTests/StatusesTests.swift
+++ b/Tests/OctoKitTests/StatusesTests.swift
@@ -11,7 +11,8 @@ class StatusesTests: XCTestCase {
                                             statusCode: 201)
 
         let task = Octokit().createCommitStatus(session, owner: "octocat", repository: "Hello-World", sha: "6dcb09b5b57875f334f61aebed695e2e4193db5e", state: .success,
-                                                targetURL: "https://example.com/build/status", description: "The build succeeded!", context: "continuous-integration/jenkins") { response in
+                                                targetURL: "https://example.com/build/status", description: "The build succeeded!", context: "continuous-integration/jenkins")
+        { response in
             switch response {
             case let .success(status):
                 XCTAssertEqual(status.id, 1)

--- a/fastlane/.env.default
+++ b/fastlane/.env.default
@@ -1,6 +1,6 @@
-AF_IOS_SDK=iphonesimulator14.3
-AF_MAC_SDK=macosx11.0
-AF_TVOS_SDK=appletvsimulator14.3
+AF_IOS_SDK=iphonesimulator15.0
+AF_MAC_SDK=macosx12.0
+AF_TVOS_SDK=appletvsimulator15.0
 
 AF_CONFIGURATION=Release
 

--- a/fastlane/.env.ios
+++ b/fastlane/.env.ios
@@ -1,3 +1,3 @@
-SCAN_DEVICE="iPhone 8"
+SCAN_DEVICE="iPhone 12"
 SCAN_SDK=$AF_IOS_SDK
-EXAMPLE_DESTINATION="platform=iOS Simulator,name=iPhone 8"
+EXAMPLE_DESTINATION="platform=iOS Simulator,name=iPhone 12"


### PR DESCRIPTION
As the title suggests: Use RequestKit 3.0.0 which removed `Response` and use native `Result` type instead.