### PR TITLE
repository: make "size" field optional

### DIFF
--- a/OctoKit/Repositories.swift
+++ b/OctoKit/Repositories.swift
@@ -18,7 +18,7 @@ open class Repository: Codable {
     open var sshURL: String?
     open var cloneURL: String?
     open var htmlURL: String?
-    open private(set) var size: Int = -1
+    open private(set) var size: Int? = -1
     open var lastPush: Date?
     open var stargazersCount: Int?
 


### PR DESCRIPTION
Make `Repository.size` optional.
When requesting for GH activity (notifications list) the `size` field of the repository dict is not present (see example of the reply in the end of the PR description).
It's consistent with GH's API [documentation](https://docs.github.com/en/rest/reference/activity#list-notifications-for-the-authenticated-user).

When calling `Octokit(config).myNotifications` I'm getting following error:
```
keyNotFound(CodingKeys(stringValue: "size", intValue: nil), Swift.DecodingError.Context(codingPath: [_JSONKey(stringValue: "Index 0", intValue: 0), CodingKeys(stringValue: "repository", intValue: nil)], debugDescription: "No value associated with key CodingKeys(stringValue: \"size\", intValue: nil) (\"size\").", underlyingError: nil))
```

Example of GH's reply:
```json
  {
    "id": "2687890487",
    "unread": true,
    "reason": "subscribed",
    "updated_at": "2021-11-15T13:46:22Z",
    "last_read_at": null,
    "subject": {
      "title": "Why was the file /ext/nio4r/nio4r_ext.c added to ignore?",
      "url": "https://api.github.com/repos/socketry/nio4r/issues/279",
      "latest_comment_url": "https://api.github.com/repos/socketry/nio4r/issues/279",
      "type": "Issue"
    },
    "repository": {
      "id": 3030982,
      "node_id": "MDEwOlJlcG9zaXRvcnkzMDMwOTgy",
      "name": "nio4r",
      "full_name": "socketry/nio4r",
      "private": false,
      "owner": {
        "login": "socketry",
        "id": 22138037,
        "node_id": "MDEyOk9yZ2FuaXphdGlvbjIyMTM4MDM3",
        "avatar_url": "https://avatars.githubusercontent.com/u/22138037?v=4",
        "gravatar_id": "",
        "url": "https://api.github.com/users/socketry",
        "html_url": "https://github.com/socketry",
        "followers_url": "https://api.github.com/users/socketry/followers",
        "following_url": "https://api.github.com/users/socketry/following{/other_user}",
        "gists_url": "https://api.github.com/users/socketry/gists{/gist_id}",
        "starred_url": "https://api.github.com/users/socketry/starred{/owner}{/repo}",
        "subscriptions_url": "https://api.github.com/users/socketry/subscriptions",
        "organizations_url": "https://api.github.com/users/socketry/orgs",
        "repos_url": "https://api.github.com/users/socketry/repos",
        "events_url": "https://api.github.com/users/socketry/events{/privacy}",
        "received_events_url": "https://api.github.com/users/socketry/received_events",
        "type": "Organization",
        "site_admin": false
      },
      "html_url": "https://github.com/socketry/nio4r",
      "description": "Cross-platform asynchronous I/O primitives for scalable network clients and servers.",
      "fork": false,
      "url": "https://api.github.com/repos/socketry/nio4r",
      "forks_url": "https://api.github.com/repos/socketry/nio4r/forks",
      "keys_url": "https://api.github.com/repos/socketry/nio4r/keys{/key_id}",
      "collaborators_url": "https://api.github.com/repos/socketry/nio4r/collaborators{/collaborator}",
      "teams_url": "https://api.github.com/repos/socketry/nio4r/teams",
      "hooks_url": "https://api.github.com/repos/socketry/nio4r/hooks",
      "issue_events_url": "https://api.github.com/repos/socketry/nio4r/issues/events{/number}",
      "events_url": "https://api.github.com/repos/socketry/nio4r/events",
      "assignees_url": "https://api.github.com/repos/socketry/nio4r/assignees{/user}",
      "branches_url": "https://api.github.com/repos/socketry/nio4r/branches{/branch}",
      "tags_url": "https://api.github.com/repos/socketry/nio4r/tags",
      "blobs_url": "https://api.github.com/repos/socketry/nio4r/git/blobs{/sha}",
      "git_tags_url": "https://api.github.com/repos/socketry/nio4r/git/tags{/sha}",
      "git_refs_url": "https://api.github.com/repos/socketry/nio4r/git/refs{/sha}",
      "trees_url": "https://api.github.com/repos/socketry/nio4r/git/trees{/sha}",
      "statuses_url": "https://api.github.com/repos/socketry/nio4r/statuses/{sha}",
      "languages_url": "https://api.github.com/repos/socketry/nio4r/languages",
      "stargazers_url": "https://api.github.com/repos/socketry/nio4r/stargazers",
      "contributors_url": "https://api.github.com/repos/socketry/nio4r/contributors",
      "subscribers_url": "https://api.github.com/repos/socketry/nio4r/subscribers",
      "subscription_url": "https://api.github.com/repos/socketry/nio4r/subscription",
      "commits_url": "https://api.github.com/repos/socketry/nio4r/commits{/sha}",
      "git_commits_url": "https://api.github.com/repos/socketry/nio4r/git/commits{/sha}",
      "comments_url": "https://api.github.com/repos/socketry/nio4r/comments{/number}",
      "issue_comment_url": "https://api.github.com/repos/socketry/nio4r/issues/comments{/number}",
      "contents_url": "https://api.github.com/repos/socketry/nio4r/contents/{+path}",
      "compare_url": "https://api.github.com/repos/socketry/nio4r/compare/{base}...{head}",
      "merges_url": "https://api.github.com/repos/socketry/nio4r/merges",
      "archive_url": "https://api.github.com/repos/socketry/nio4r/{archive_format}{/ref}",
      "downloads_url": "https://api.github.com/repos/socketry/nio4r/downloads",
      "issues_url": "https://api.github.com/repos/socketry/nio4r/issues{/number}",
      "pulls_url": "https://api.github.com/repos/socketry/nio4r/pulls{/number}",
      "milestones_url": "https://api.github.com/repos/socketry/nio4r/milestones{/number}",
      "notifications_url": "https://api.github.com/repos/socketry/nio4r/notifications{?since,all,participating}",
      "labels_url": "https://api.github.com/repos/socketry/nio4r/labels{/name}",
      "releases_url": "https://api.github.com/repos/socketry/nio4r/releases{/id}",
      "deployments_url": "https://api.github.com/repos/socketry/nio4r/deployments"
    },
    "url": "https://api.github.com/notifications/threads/2687890487",
    "subscription_url": "https://api.github.com/notifications/threads/2687890487/subscription"
  },
```