### PR TITLE
make OctoKit struct constructor accept any custom configuration

### DIFF
--- a/OctoKit/Octokit.swift
+++ b/OctoKit/Octokit.swift
@@ -1,9 +1,10 @@
 import Foundation
+import RequestKit
 
 public struct Octokit {
-    public let configuration: TokenConfiguration
+    public let configuration: Configuration
 
-    public init(_ config: TokenConfiguration = TokenConfiguration()) {
+    public init(_ config: Configuration = TokenConfiguration()) {
         configuration = config
     }
 }


### PR DESCRIPTION
I would like to do smth like
```
public struct CustomTokenConfiguration: Configuration {
    public var apiEndpoint: String = githubBaseURL
    public var accessToken: String?
    public let errorDomain = OctoKitErrorDomain
    public let authorizationHeader: String? = "token"

    public var customHeaders: [HTTPHeader]? = [
        HTTPHeader(headerField: "cache-control", value: "no-cache"),
    ]

    public init(_ token: String? = nil) {
        accessToken = token
    }
}
```


For context, it appears that `RequestKit` uses [default](https://developer.apple.com/documentation/foundation/nsurlrequest/cachepolicy/useprotocolcachepolicy) cache policy which for some reason does not always plays nicely with GH API.

I didn't dig too much into details of the implementation but disabling local cache always allowed fetch the most up-to date data. I tend to blame the `ETag` response value as it seems to be present but always empty.

Alternatively, it should be possible to expose [cachePolicy](https://developer.apple.com/documentation/foundation/nsurlrequest/1416292-init) of the `URLRequest` (which is probably better) but I think this is still a good evolution of `OctoKit` to allow people define custom headers easily.