### PR TITLE
Add `perPage` argument to list releases, delete release, delete reference endpoints

### DIFF
--- a/OctoKit/Git.swift
+++ b/OctoKit/Git.swift
@@ -1,0 +1,74 @@
+//
+//  Git.swift
+//  OctoKit
+//
+//  Created by Antoine van der Lee on 25/01/2022.
+//  Copyright © 2020 nerdish by nature. All rights reserved.
+//
+
+import Foundation
+import RequestKit
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+// MARK: request
+
+public extension Octokit {
+    /// Deletes a reference.
+    /// - Parameters:
+    ///   - session: RequestKitURLSession, defaults to URLSession.shared()
+    ///   - owner: The user or organization that owns the repositories.
+    ///   - repo: The repository on which the reference needs to be deleted.
+    ///   - ref: The reference to delete.
+    ///   - completion: Callback for the outcome of the deletion.
+    @discardableResult
+    func deleteReference(_ session: RequestKitURLSession = URLSession.shared,
+                       owner: String,
+                       repository: String,
+                       ref: String,
+                       completion: @escaping (_ response: Error?) -> Void) -> URLSessionDataTaskProtocol? {
+        let router = GITRouter.deleteReference(configuration, owner, repository, ref)
+        return router.load(session, completion: completion)
+    }
+}
+
+// MARK: Router
+
+enum GITRouter: JSONPostRouter {
+    case deleteReference(Configuration, String, String, String)
+
+    var configuration: Configuration {
+        switch self {
+        case let .deleteReference(config, _, _, _): return config
+        }
+    }
+
+    var method: HTTPMethod {
+        switch self {
+        case .deleteReference:
+            return .DELETE
+        }
+    }
+
+    var encoding: HTTPEncoding {
+        switch self {
+        case .deleteReference:
+            return .url
+        }
+    }
+
+    var params: [String: Any] {
+        switch self {
+        case .deleteReference:
+            return [:]
+        }
+    }
+
+    var path: String {
+        switch self {
+        case let .deleteReference(_, owner, repo, reference):
+            return "repos/\(owner)/\(repo)/git/refs/\(reference)"
+        }
+    }
+}

--- a/OctoKit/Git.swift
+++ b/OctoKit/Git.swift
@@ -24,10 +24,11 @@ public extension Octokit {
     ///   - completion: Callback for the outcome of the deletion.
     @discardableResult
     func deleteReference(_ session: RequestKitURLSession = URLSession.shared,
-                       owner: String,
-                       repository: String,
-                       ref: String,
-                       completion: @escaping (_ response: Error?) -> Void) -> URLSessionDataTaskProtocol? {
+                         owner: String,
+                         repository: String,
+                         ref: String,
+                         completion: @escaping (_ response: Error?) -> Void) -> URLSessionDataTaskProtocol?
+    {
         let router = GITRouter.deleteReference(configuration, owner, repository, ref)
         return router.load(session, completion: completion)
     }

--- a/OctoKit/Releases.swift
+++ b/OctoKit/Releases.swift
@@ -127,7 +127,8 @@ public extension Octokit {
                        owner: String,
                        repository: String,
                        releaseId: Int,
-                       completion: @escaping (_ response: Error?) -> Void) -> URLSessionDataTaskProtocol? {
+                       completion: @escaping (_ response: Error?) -> Void) -> URLSessionDataTaskProtocol?
+    {
         let router = ReleaseRouter.deleteRelease(configuration, owner, repository, releaseId)
         return router.load(session, completion: completion)
     }

--- a/OctoKit/Releases.swift
+++ b/OctoKit/Releases.swift
@@ -119,7 +119,7 @@ public extension Octokit {
     /// - Parameters:
     ///   - session: RequestKitURLSession, defaults to URLSession.shared()
     ///   - owner: The user or organization that owns the repositories.
-    ///   - repo: The repository on which the release needs to be created.
+    ///   - repo: The repository on which the release needs to be deleted.
     ///   - releaseId: The ID of the release to delete.
     ///   - completion: Callback for the outcome of the deletion.
     @discardableResult

--- a/OctoKit/Releases.swift
+++ b/OctoKit/Releases.swift
@@ -114,6 +114,23 @@ public extension Octokit {
             }
         }
     }
+
+    /// Deletes a release.
+    /// - Parameters:
+    ///   - session: RequestKitURLSession, defaults to URLSession.shared()
+    ///   - owner: The user or organization that owns the repositories.
+    ///   - repo: The repository on which the release needs to be created.
+    ///   - releaseId: The ID of the release to delete.
+    ///   - completion: Callback for the outcome of the deletion.
+    @discardableResult
+    func deleteRelease(_ session: RequestKitURLSession = URLSession.shared,
+                       owner: String,
+                       repository: String,
+                       releaseId: Int,
+                       completion: @escaping (_ response: Error?) -> Void) -> URLSessionDataTaskProtocol? {
+        let router = ReleaseRouter.deleteRelease(configuration, owner, repository, releaseId)
+        return router.load(session, completion: completion)
+    }
 }
 
 // MARK: Router
@@ -121,11 +138,13 @@ public extension Octokit {
 enum ReleaseRouter: JSONPostRouter {
     case listReleases(Configuration, String, String, Int)
     case postRelease(Configuration, String, String, String, String?, String?, String?, Bool, Bool)
+    case deleteRelease(Configuration, String, String, Int)
 
     var configuration: Configuration {
         switch self {
         case let .listReleases(config, _, _, _): return config
         case let .postRelease(config, _, _, _, _, _, _, _, _): return config
+        case let .deleteRelease(config, _, _, _): return config
         }
     }
 
@@ -135,6 +154,8 @@ enum ReleaseRouter: JSONPostRouter {
             return .GET
         case .postRelease:
             return .POST
+        case .deleteRelease:
+            return .DELETE
         }
     }
 
@@ -144,6 +165,8 @@ enum ReleaseRouter: JSONPostRouter {
             return .url
         case .postRelease:
             return .json
+        case .deleteRelease:
+            return .url
         }
     }
 
@@ -167,6 +190,8 @@ enum ReleaseRouter: JSONPostRouter {
                 params["body"] = body
             }
             return params
+        case .deleteRelease:
+            return [:]
         }
     }
 
@@ -176,6 +201,8 @@ enum ReleaseRouter: JSONPostRouter {
             return "repos/\(owner)/\(repo)/releases"
         case let .postRelease(_, owner, repo, _, _, _, _, _, _):
             return "repos/\(owner)/\(repo)/releases"
+        case let .deleteRelease(_, owner, repo, releaseId):
+            return "repos/\(owner)/\(repo)/releases/\(releaseId)"
         }
     }
 }

--- a/Tests/OctoKitTests/ReleasesTests.swift
+++ b/Tests/OctoKitTests/ReleasesTests.swift
@@ -13,7 +13,7 @@ final class ReleasesTests: XCTestCase {
     // MARK: Actual Request tests
 
     func testListReleases() {
-        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/Hello-World/releases", expectedHTTPMethod: "GET", jsonFile: "Fixtures/releases", statusCode: 200)
+        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/Hello-World/releases?per_page=30", expectedHTTPMethod: "GET", jsonFile: "Fixtures/releases", statusCode: 200)
         let task = Octokit().listReleases(session, owner: "octocat", repository: "Hello-World") {
             switch $0 {
             case let .success(releases):
@@ -44,6 +44,21 @@ final class ReleasesTests: XCTestCase {
                 } else {
                     XCTFail("Failed to unwrap `releases.last`")
                 }
+            case let .failure(error):
+                XCTAssert(false, "Endpoint failed with error \(error)")
+            }
+        }
+        XCTAssertNotNil(task)
+        XCTAssertTrue(session.wasCalled)
+    }
+
+    func testListReleasesCustomLimit() {
+        let perPage = (0...50).randomElement()!
+        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/Hello-World/releases?per_page=\(perPage)", expectedHTTPMethod: "GET", jsonFile: "Fixtures/releases", statusCode: 200)
+        let task = Octokit().listReleases(session, owner: "octocat", repository: "Hello-World", perPage: perPage) {
+            switch $0 {
+            case .success:
+                break
             case let .failure(error):
                 XCTAssert(false, "Endpoint failed with error \(error)")
             }

--- a/Tests/OctoKitTests/ReleasesTests.swift
+++ b/Tests/OctoKitTests/ReleasesTests.swift
@@ -13,7 +13,12 @@ final class ReleasesTests: XCTestCase {
     // MARK: Actual Request tests
 
     func testListReleases() {
-        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/Hello-World/releases?per_page=30", expectedHTTPMethod: "GET", jsonFile: "Fixtures/releases", statusCode: 200)
+        let session = OctoKitURLTestSession(
+            expectedURL: "https://api.github.com/repos/octocat/Hello-World/releases?per_page=30",
+            expectedHTTPMethod: "GET",
+            jsonFile: "Fixtures/releases",
+            statusCode: 200
+        )
         let task = Octokit().listReleases(session, owner: "octocat", repository: "Hello-World") {
             switch $0 {
             case let .success(releases):
@@ -53,8 +58,13 @@ final class ReleasesTests: XCTestCase {
     }
 
     func testListReleasesCustomLimit() {
-        let perPage = (0...50).randomElement()!
-        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/Hello-World/releases?per_page=\(perPage)", expectedHTTPMethod: "GET", jsonFile: "Fixtures/releases", statusCode: 200)
+        let perPage = (0 ... 50).randomElement()!
+        let session = OctoKitURLTestSession(
+            expectedURL: "https://api.github.com/repos/octocat/Hello-World/releases?per_page=\(perPage)",
+            expectedHTTPMethod: "GET",
+            jsonFile: "Fixtures/releases",
+            statusCode: 200
+        )
         let task = Octokit().listReleases(session, owner: "octocat", repository: "Hello-World", perPage: perPage) {
             switch $0 {
             case .success:

--- a/Tests/OctoKitTests/StatusesTests.swift
+++ b/Tests/OctoKitTests/StatusesTests.swift
@@ -11,8 +11,7 @@ class StatusesTests: XCTestCase {
                                             statusCode: 201)
 
         let task = Octokit().createCommitStatus(session, owner: "octocat", repository: "Hello-World", sha: "6dcb09b5b57875f334f61aebed695e2e4193db5e", state: .success,
-                                                targetURL: "https://example.com/build/status", description: "The build succeeded!", context: "continuous-integration/jenkins")
-        { response in
+                                                targetURL: "https://example.com/build/status", description: "The build succeeded!", context: "continuous-integration/jenkins") { response in
             switch response {
             case let .success(status):
                 XCTAssertEqual(status.id, 1)

--- a/Tests/OctoKitTests/StatusesTests.swift
+++ b/Tests/OctoKitTests/StatusesTests.swift
@@ -11,7 +11,8 @@ class StatusesTests: XCTestCase {
                                             statusCode: 201)
 
         let task = Octokit().createCommitStatus(session, owner: "octocat", repository: "Hello-World", sha: "6dcb09b5b57875f334f61aebed695e2e4193db5e", state: .success,
-                                                targetURL: "https://example.com/build/status", description: "The build succeeded!", context: "continuous-integration/jenkins") { response in
+                                                targetURL: "https://example.com/build/status", description: "The build succeeded!", context: "continuous-integration/jenkins")
+        { response in
             switch response {
             case let .success(status):
                 XCTAssertEqual(status.id, 1)


### PR DESCRIPTION
- [x] Adds a `perPage` parameter to the list releases endpoint
- [x] Adds the delete release endpoint
- [x] Adds the delete reference endpoint

I did not add tests for the deletion endpoints since they require decoding and would not leave much of a valuable unit test looking at the other written unit tests. 
The test for the releases per page argument has been updated accordingly.