### PR TITLE
Star/unstar repository

### DIFF
--- a/OctoKit/Stars.swift
+++ b/OctoKit/Stars.swift
@@ -55,7 +55,8 @@ public extension Octokit {
     func star(_ session: RequestKitURLSession = URLSession.shared,
               owner: String,
               repository: String,
-              completion: @escaping (_ response: Result<Bool, Error>) -> Void) -> URLSessionDataTaskProtocol? {
+              completion: @escaping (_ response: Result<Bool, Error>) -> Void) -> URLSessionDataTaskProtocol?
+    {
         let router = StarsRouter.readStar(configuration, owner, repository)
         return router.load(session) { error in
             guard let error = error else {
@@ -81,7 +82,8 @@ public extension Octokit {
     func putStar(_ session: RequestKitURLSession = URLSession.shared,
                  owner: String,
                  repository: String,
-                 completion: @escaping (_ response: Error?) -> Void) -> URLSessionDataTaskProtocol? {
+                 completion: @escaping (_ response: Error?) -> Void) -> URLSessionDataTaskProtocol?
+    {
         let router = StarsRouter.putStar(configuration, owner, repository)
         return router.load(session, completion: completion)
     }
@@ -97,7 +99,8 @@ public extension Octokit {
     func deleteStar(_ session: RequestKitURLSession = URLSession.shared,
                     owner: String,
                     repository: String,
-                    completion: @escaping (_ response: Error?) -> Void) -> URLSessionDataTaskProtocol? {
+                    completion: @escaping (_ response: Error?) -> Void) -> URLSessionDataTaskProtocol?
+    {
         let router = StarsRouter.deleteStar(configuration, owner, repository)
         return router.load(session, completion: completion)
     }
@@ -126,8 +129,8 @@ enum StarsRouter: Router {
         case let .readAuthenticatedStars(config): return config
         case let .readStars(_, config): return config
         case let .readStar(config, _, _): return config
-        case let .putStar(config, _ , _): return config
-        case let .deleteStar(config, _ , _): return config
+        case let .putStar(config, _, _): return config
+        case let .deleteStar(config, _, _): return config
         }
     }
 

--- a/OctoKit/Stars.swift
+++ b/OctoKit/Stars.swift
@@ -85,6 +85,22 @@ public extension Octokit {
         let router = StarsRouter.putStar(configuration, owner, repository)
         return router.load(session, completion: completion)
     }
+
+    /**
+     Unstars a repository for the authenticated user
+     - parameter session: RequestKitURLSession, defaults to URLSession.sharedSession()
+     - parameter owner: The name of the owner of the repository.
+     - parameter repository: The name of the repository.
+     - parameter completion: Callback for the outcome of the fetch.
+     */
+    @discardableResult
+    func deleteStar(_ session: RequestKitURLSession = URLSession.shared,
+                    owner: String,
+                    repository: String,
+                    completion: @escaping (_ response: Error?) -> Void) -> URLSessionDataTaskProtocol? {
+        let router = StarsRouter.deleteStar(configuration, owner, repository)
+        return router.load(session, completion: completion)
+    }
 }
 
 enum StarsRouter: Router {
@@ -92,12 +108,16 @@ enum StarsRouter: Router {
     case readStars(String, Configuration)
     case readStar(Configuration, String, String)
     case putStar(Configuration, String, String)
+    case deleteStar(Configuration, String, String)
+
     var method: HTTPMethod {
         switch self {
         case .readAuthenticatedStars, .readStars, .readStar:
-        return .GET
+            return .GET
         case .putStar:
             return .PUT
+        case .deleteStar:
+            return .DELETE
         }
     }
 
@@ -107,6 +127,7 @@ enum StarsRouter: Router {
         case let .readStars(_, config): return config
         case let .readStar(config, _, _): return config
         case let .putStar(config, _ , _): return config
+        case let .deleteStar(config, _ , _): return config
         }
     }
 
@@ -123,6 +144,8 @@ enum StarsRouter: Router {
         case let .readStar(_, owner, repository):
             return "/user/starred/\(owner)/\(repository)"
         case let .putStar(_, owner, repository):
+            return "/user/starred/\(owner)/\(repository)"
+        case let .deleteStar(_, owner, repository):
             return "/user/starred/\(owner)/\(repository)"
         }
     }

--- a/OctoKit/Stars.swift
+++ b/OctoKit/Stars.swift
@@ -69,14 +69,36 @@ public extension Octokit {
             completion(.failure(error))
         }
     }
+
+    /**
+     Stars a repository for the authenticated user
+     - parameter session: RequestKitURLSession, defaults to URLSession.sharedSession()
+     - parameter owner: The name of the owner of the repository.
+     - parameter repository: The name of the repository.
+     - parameter completion: Callback for the outcome of the fetch.
+     */
+    @discardableResult
+    func putStar(_ session: RequestKitURLSession = URLSession.shared,
+                 owner: String,
+                 repository: String,
+                 completion: @escaping (_ response: Error?) -> Void) -> URLSessionDataTaskProtocol? {
+        let router = StarsRouter.putStar(configuration, owner, repository)
+        return router.load(session, completion: completion)
+    }
 }
 
 enum StarsRouter: Router {
     case readAuthenticatedStars(Configuration)
     case readStars(String, Configuration)
     case readStar(Configuration, String, String)
+    case putStar(Configuration, String, String)
     var method: HTTPMethod {
+        switch self {
+        case .readAuthenticatedStars, .readStars, .readStar:
         return .GET
+        case .putStar:
+            return .PUT
+        }
     }
 
     var configuration: Configuration {
@@ -84,6 +106,7 @@ enum StarsRouter: Router {
         case let .readAuthenticatedStars(config): return config
         case let .readStars(_, config): return config
         case let .readStar(config, _, _): return config
+        case let .putStar(config, _ , _): return config
         }
     }
 
@@ -98,6 +121,8 @@ enum StarsRouter: Router {
         case let .readStars(username, _):
             return "users/\(username)/starred"
         case let .readStar(_, owner, repository):
+            return "/user/starred/\(owner)/\(repository)"
+        case let .putStar(_, owner, repository):
             return "/user/starred/\(owner)/\(repository)"
         }
     }

--- a/Tests/OctoKitTests/StarsTests.swift
+++ b/Tests/OctoKitTests/StarsTests.swift
@@ -67,4 +67,66 @@ class StarsTests: XCTestCase {
         XCTAssertNotNil(task)
         XCTAssertTrue(session.wasCalled)
     }
+
+    func testGetStarFromNotStarredRepository() {
+        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/user/starred/octocat/Hello-World", expectedHTTPMethod: "GET", jsonFile: nil, statusCode: 404)
+        let task = Octokit().star(
+            session,
+            owner: "octocat",
+            repository: "Hello-World"
+        ) { response in
+            switch response {
+            case let .success(flag):
+                XCTAssertFalse(flag)
+            case .failure:
+                XCTFail("should not get an error")
+            }
+        }
+        XCTAssertNotNil(task)
+        XCTAssertTrue(session.wasCalled)
+    }
+
+    func testGetStarFromStarredRepository() {
+        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/user/starred/octocat/Hello-World", expectedHTTPMethod: "GET", jsonFile: nil, statusCode: 204)
+        let task = Octokit().star(
+            session,
+            owner: "octocat",
+            repository: "Hello-World"
+        ) { response in
+            switch response {
+            case let .success(flag):
+                XCTAssertTrue(flag)
+            case .failure:
+                XCTFail("should not get an error")
+            }
+        }
+        XCTAssertNotNil(task)
+        XCTAssertTrue(session.wasCalled)
+    }
+
+    func testPutStar() {
+        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/user/starred/octocat/Hello-World", expectedHTTPMethod: "PUT", jsonFile: nil, statusCode: 204)
+        let task = Octokit().putStar(
+            session,
+            owner: "octocat",
+            repository: "Hello-World"
+        ) { response in
+            XCTAssertNil(response)
+        }
+        XCTAssertNotNil(task)
+        XCTAssertTrue(session.wasCalled)
+    }
+
+    func testDeleteStar() {
+        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/user/starred/octocat/Hello-World", expectedHTTPMethod: "DELETE", jsonFile: nil, statusCode: 204)
+        let task = Octokit().deleteStar(
+            session,
+            owner: "octocat",
+            repository: "Hello-World"
+        ) { response in
+            XCTAssertNil(response)
+        }
+        XCTAssertNotNil(task)
+        XCTAssertTrue(session.wasCalled)
+    }
 }


### PR DESCRIPTION
Implementing these three calls:
- `GET /user/starred/{owner}/{repo}`
  - https://docs.github.com/en/rest/reference/activity#check-if-a-repository-is-starred-by-the-authenticated-user
- `PUT /user/starred/{owner}/{repo}`
  - https://docs.github.com/en/rest/reference/activity#star-a-repository-for-the-authenticated-user
- `DELETE /user/starred/{owner}/{repo}`
  - https://docs.github.com/en/rest/reference/activity#unstar-a-repository-for-the-authenticated-user