### PR TITLE
Update readme version and fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ import PackageDescription
 let package = Package(
   name: "MyAwesomeApp",
     dependencies: [
-      .package(url: "https://github.com/nerdishbynature/octokit.swift", from: "0.9.0"),
+      .package(url: "https://github.com/nerdishbynature/octokit.swift", from: "0.11.0"),
     ]
   )
 ```

--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ Octokit().pullRequest(owner: "octocat", repository: "Hello-World", number: 1) { 
 }
 ```
 
-### List a pull requests
+### List pull requests
 ```swift
 Octokit().pullRequests(owner: "octocat", repository: "Hello-World", base: "develop", state: Openness.Open) { response in
     switch response {


### PR DESCRIPTION
Replace `0.9.0` with `0.11.0`. That way it is clearer what's the latest version 😄 