### PR TITLE
feat: add optional generation of release notes

### DIFF
--- a/Tests/OctoKitTests/ReleasesTests.swift
+++ b/Tests/OctoKitTests/ReleasesTests.swift
@@ -129,7 +129,8 @@ final class ReleasesTests: XCTestCase {
             name: "v1.0.0 Release",
             body: "The changelog of this release",
             prerelease: false,
-            draft: false
+            draft: false,
+            generateNotes: false
         ) { response in
             switch response {
             case let .success(release):
@@ -185,7 +186,8 @@ final class ReleasesTests: XCTestCase {
             name: "v1.0.0 Release",
             body: "The changelog of this release",
             prerelease: false,
-            draft: false
+            draft: false,
+            generateNotes: false
         )
         XCTAssertEqual(release.tagName, "v1.0.0")
         XCTAssertEqual(release.commitish, "master")


### PR DESCRIPTION
This small PR adds the possibility to add an additional flag to generate release notes. 

More information about the Github API generation of release notes can be found [here](https://docs.github.com/en/rest/releases/releases#generate-release-notes-content-for-a-release)