### PR TITLE
Allow for authorization header to be set

### DIFF
--- a/OctoKit/Configuration.swift
+++ b/OctoKit/Configuration.swift
@@ -13,7 +13,7 @@ public struct TokenConfiguration: Configuration {
     public var apiEndpoint: String
     public var accessToken: String?
     public let errorDomain = OctoKitErrorDomain
-    public let authorizationHeader: String? = "Basic"
+    public var authorizationHeader: String? = "Basic"
 
     /// Custom `Accept` header for API previews.
     ///

--- a/OctoKit/Configuration.swift
+++ b/OctoKit/Configuration.swift
@@ -13,7 +13,7 @@ public struct TokenConfiguration: Configuration {
     public var apiEndpoint: String
     public var accessToken: String?
     public let errorDomain = OctoKitErrorDomain
-    public var authorizationHeader: String? = "Basic"
+    public let authorizationHeader: Optional<String>
 
     /// Custom `Accept` header for API previews.
     ///
@@ -28,7 +28,15 @@ public struct TokenConfiguration: Configuration {
 
     public init(_ token: String? = nil, url: String = githubBaseURL, previewHeaders: [PreviewHeader] = []) {
         apiEndpoint = url
+        authorizationHeader = "Basic"
         accessToken = token?.data(using: .utf8)!.base64EncodedString()
+        previewCustomHeaders = previewHeaders.map { $0.header }
+    }
+
+    public init(bearerToken: String, url: String = githubBaseURL, previewHeaders: [PreviewHeader] = []) {
+        apiEndpoint = url
+        authorizationHeader = "Bearer"
+        accessToken = bearerToken
         previewCustomHeaders = previewHeaders.map { $0.header }
     }
 }

--- a/OctoKit/Configuration.swift
+++ b/OctoKit/Configuration.swift
@@ -13,7 +13,7 @@ public struct TokenConfiguration: Configuration {
     public var apiEndpoint: String
     public var accessToken: String?
     public let errorDomain = OctoKitErrorDomain
-    public let authorizationHeader: Optional<String>
+    public private(set) var authorizationHeader: String? = "Basic"
 
     /// Custom `Accept` header for API previews.
     ///
@@ -28,7 +28,6 @@ public struct TokenConfiguration: Configuration {
 
     public init(_ token: String? = nil, url: String = githubBaseURL, previewHeaders: [PreviewHeader] = []) {
         apiEndpoint = url
-        authorizationHeader = "Basic"
         accessToken = token?.data(using: .utf8)!.base64EncodedString()
         previewCustomHeaders = previewHeaders.map { $0.header }
     }


### PR DESCRIPTION
This change allows for consumers of octokit.swift to send requests with authorization other than basic.

The motivation for this change is that Swift scripts that use octokit.swift triggered by actions in a private repo cannot use the default `GITHUB_TOKEN` with basic authorization, and instead must create and use a secret personal access token. In order to remedy this, the requests need to be authorized with a bearer token using the  `Authorization` authorization header and a `Bearer [token]` value. 

This is the smallest possible change to enable this behavior. In use it would look like:

```swift
var tokenConfiguration = TokenConfiguration()
tokenConfiguration.authorizationHeader = "Bearer"
tokenConfiguration.accessToken = token
let octokit = Octokit(tokenConfiguration)
```