### PR TITLE
Move URLSession to Octokit instead of having it in every method

### DIFF
--- a/OctoKit/Follow.swift
+++ b/OctoKit/Follow.swift
@@ -7,11 +7,10 @@ import FoundationNetworking
 public extension Octokit {
     /**
          Fetches the followers of the authenticated user
-         - parameter session: RequestKitURLSession, defaults to URLSession.shared
          - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func myFollowers(_ session: RequestKitURLSession = URLSession.shared, completion: @escaping (_ response: Result<[User], Error>) -> Void) -> URLSessionDataTaskProtocol? {
+    func myFollowers(completion: @escaping (_ response: Result<[User], Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = FollowRouter.readAuthenticatedFollowers(configuration)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [User].self) { users, error in
             if let error = error {
@@ -27,10 +26,9 @@ public extension Octokit {
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     /**
          Fetches the followers of the authenticated user
-         - parameter session: RequestKitURLSession, defaults to URLSession.shared
      */
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func myFollowers(_ session: RequestKitURLSession = URLSession.shared) async throws -> [User] {
+    func myFollowers() async throws -> [User] {
         let router = FollowRouter.readAuthenticatedFollowers(configuration)
         return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [User].self)
     }
@@ -38,12 +36,11 @@ public extension Octokit {
 
     /**
          Fetches the followers of a user
-         - parameter session: RequestKitURLSession, defaults to URLSession.shared
          - parameter name: Name of the user
          - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func followers(_ session: RequestKitURLSession = URLSession.shared, name: String, completion: @escaping (_ response: Result<[User], Error>) -> Void) -> URLSessionDataTaskProtocol? {
+    func followers(name: String, completion: @escaping (_ response: Result<[User], Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = FollowRouter.readFollowers(name, configuration)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [User].self) { users, error in
             if let error = error {
@@ -59,11 +56,10 @@ public extension Octokit {
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     /**
          Fetches the followers of a user
-         - parameter session: RequestKitURLSession, defaults to URLSession.shared
          - parameter name: Name of the user
      */
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func followers(_ session: RequestKitURLSession = URLSession.shared, name: String) async throws -> [User] {
+    func followers(name: String) async throws -> [User] {
         let router = FollowRouter.readFollowers(name, configuration)
         return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [User].self)
     }
@@ -71,11 +67,10 @@ public extension Octokit {
 
     /**
          Fetches the users following the authenticated user
-         - parameter session: RequestKitURLSession, defaults to URLSession.shared
          - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func myFollowing(_ session: RequestKitURLSession = URLSession.shared, completion: @escaping (_ response: Result<[User], Error>) -> Void) -> URLSessionDataTaskProtocol? {
+    func myFollowing(completion: @escaping (_ response: Result<[User], Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = FollowRouter.readAuthenticatedFollowing(configuration)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [User].self) { users, error in
             if let error = error {
@@ -91,10 +86,9 @@ public extension Octokit {
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     /**
          Fetches the users following the authenticated user
-         - parameter session: RequestKitURLSession, defaults to URLSession.shared
      */
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func myFollowing(_ session: RequestKitURLSession = URLSession.shared) async throws -> [User] {
+    func myFollowing() async throws -> [User] {
         let router = FollowRouter.readAuthenticatedFollowing(configuration)
         return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [User].self)
     }
@@ -102,12 +96,11 @@ public extension Octokit {
 
     /**
          Fetches the users following a user
-         - parameter session: RequestKitURLSession, defaults to URLSession.shared
          - parameter name: The name of the user
          - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func following(_ session: RequestKitURLSession = URLSession.shared, name: String, completion: @escaping (_ response: Result<[User], Error>) -> Void) -> URLSessionDataTaskProtocol? {
+    func following(name: String, completion: @escaping (_ response: Result<[User], Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = FollowRouter.readFollowing(name, configuration)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [User].self) { users, error in
             if let error = error {
@@ -123,11 +116,10 @@ public extension Octokit {
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     /**
          Fetches the users following a user
-         - parameter session: RequestKitURLSession, defaults to URLSession.shared
          - parameter name: The name of the user
      */
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func following(_ session: RequestKitURLSession = URLSession.shared, name: String) async throws -> [User] {
+    func following(name: String) async throws -> [User] {
         let router = FollowRouter.readFollowing(name, configuration)
         return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [User].self)
     }

--- a/OctoKit/Gist.swift
+++ b/OctoKit/Gist.swift
@@ -49,14 +49,12 @@ open class Gist: Codable {
 public extension Octokit {
     /**
      Fetches the gists of the authenticated user
-     - parameter session: RequestKitURLSession, defaults to URLSession.sharedSession()
      - parameter page: Current page for gist pagination. `1` by default.
      - parameter perPage: Number of gists per page. `100` by default.
      - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func myGists(_ session: RequestKitURLSession = URLSession.shared,
-                 page: String = "1",
+    func myGists(page: String = "1",
                  perPage: String = "100",
                  completion: @escaping (_ response: Result<[Gist], Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = GistRouter.readAuthenticatedGists(configuration, page, perPage)
@@ -74,12 +72,11 @@ public extension Octokit {
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     /**
      Fetches the gists of the authenticated user
-     - parameter session: RequestKitURLSession, defaults to URLSession.sharedSession()
      - parameter page: Current page for gist pagination. `1` by default.
      - parameter perPage: Number of gists per page. `100` by default.
      */
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func myGists(_ session: RequestKitURLSession = URLSession.shared, page: String = "1", perPage: String = "100") async throws -> [Gist] {
+    func myGists(page: String = "1", perPage: String = "100") async throws -> [Gist] {
         let router = GistRouter.readAuthenticatedGists(configuration, page, perPage)
         return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Gist].self)
     }
@@ -87,15 +84,13 @@ public extension Octokit {
 
     /**
      Fetches the gists of the specified user
-     - parameter session: RequestKitURLSession, defaults to URLSession.sharedSession()
      - parameter owner: The username who owns the gists.
      - parameter page: Current page for gist pagination. `1` by default.
      - parameter perPage: Number of gists per page. `100` by default.
      - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func gists(_ session: RequestKitURLSession = URLSession.shared,
-               owner: String,
+    func gists(owner: String,
                page: String = "1",
                perPage: String = "100",
                completion: @escaping (_ response: Result<[Gist], Error>) -> Void) -> URLSessionDataTaskProtocol? {
@@ -114,13 +109,12 @@ public extension Octokit {
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     /**
      Fetches the gists of the specified user
-     - parameter session: RequestKitURLSession, defaults to URLSession.sharedSession()
      - parameter owner: The username who owns the gists.
      - parameter page: Current page for gist pagination. `1` by default.
      - parameter perPage: Number of gists per page. `100` by default.
      */
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func gists(_ session: RequestKitURLSession = URLSession.shared, owner: String, page: String = "1", perPage: String = "100") async throws -> [Gist] {
+    func gists(owner: String, page: String = "1", perPage: String = "100") async throws -> [Gist] {
         let router = GistRouter.readGists(configuration, owner, page, perPage)
         return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Gist].self)
     }
@@ -128,12 +122,11 @@ public extension Octokit {
 
     /**
      Fetches an gist
-     - parameter session: RequestKitURLSession, defaults to URLSession.sharedSession()
      - parameter id: The id of the gist.
      - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func gist(_ session: RequestKitURLSession = URLSession.shared, id: String, completion: @escaping (_ response: Result<Gist, Error>) -> Void) -> URLSessionDataTaskProtocol? {
+    func gist(id: String, completion: @escaping (_ response: Result<Gist, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = GistRouter.readGist(configuration, id)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: Gist.self) { gist, error in
             if let error = error {
@@ -149,11 +142,10 @@ public extension Octokit {
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     /**
      Fetches an gist
-     - parameter session: RequestKitURLSession, defaults to URLSession.sharedSession()
      - parameter id: The id of the gist.
      */
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func gist(_ session: RequestKitURLSession = URLSession.shared, id: String) async throws -> Gist {
+    func gist(id: String) async throws -> Gist {
         let router = GistRouter.readGist(configuration, id)
         return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: Gist.self)
     }
@@ -161,7 +153,6 @@ public extension Octokit {
 
     /**
      Creates an gist with a single file.
-     - parameter session: RequestKitURLSession, defaults to URLSession.sharedSession()
      - parameter description: The description of the gist.
      - parameter filename: The name of the file in the gist.
      - parameter fileContent: The content of the file in the gist.
@@ -169,8 +160,7 @@ public extension Octokit {
      - parameter completion: Callback for the gist that is created.
      */
     @discardableResult
-    func postGistFile(_ session: RequestKitURLSession = URLSession.shared,
-                      description: String,
+    func postGistFile(description: String,
                       filename: String,
                       fileContent: String,
                       publicAccess: Bool,
@@ -192,14 +182,13 @@ public extension Octokit {
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     /**
      Creates an gist with a single file.
-     - parameter session: RequestKitURLSession, defaults to URLSession.sharedSession()
      - parameter description: The description of the gist.
      - parameter filename: The name of the file in the gist.
      - parameter fileContent: The content of the file in the gist.
      - parameter publicAccess: The public/private visability of the gist.
      */
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func postGistFile(_ session: RequestKitURLSession = URLSession.shared, description: String, filename: String, fileContent: String, publicAccess: Bool) async throws -> Gist {
+    func postGistFile(description: String, filename: String, fileContent: String, publicAccess: Bool) async throws -> Gist {
         let router = GistRouter.postGistFile(configuration, description, filename, fileContent, publicAccess)
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(Time.rfc3339DateFormatter)
@@ -209,7 +198,6 @@ public extension Octokit {
 
     /**
      Edits an gist with a single file.
-     - parameter session: RequestKitURLSession, defaults to URLSession.sharedSession()
      - parameter id: The of the gist to update.
      - parameter description: The description of the gist.
      - parameter filename: The name of the file in the gist.
@@ -217,8 +205,7 @@ public extension Octokit {
      - parameter completion: Callback for the gist that is created.
      */
     @discardableResult
-    func patchGistFile(_ session: RequestKitURLSession = URLSession.shared,
-                       id: String,
+    func patchGistFile(id: String,
                        description: String,
                        filename: String,
                        fileContent: String,
@@ -240,14 +227,13 @@ public extension Octokit {
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     /**
      Edits an gist with a single file.
-     - parameter session: RequestKitURLSession, defaults to URLSession.sharedSession()
      - parameter id: The of the gist to update.
      - parameter description: The description of the gist.
      - parameter filename: The name of the file in the gist.
      - parameter fileContent: The content of the file in the gist.
      */
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func patchGistFile(_ session: RequestKitURLSession = URLSession.shared, id: String, description: String, filename: String, fileContent: String) async throws -> Gist {
+    func patchGistFile(id: String, description: String, filename: String, fileContent: String) async throws -> Gist {
         let router = GistRouter.patchGistFile(configuration, id, description, filename, fileContent)
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(Time.rfc3339DateFormatter)

--- a/OctoKit/Git.swift
+++ b/OctoKit/Git.swift
@@ -17,14 +17,12 @@ import FoundationNetworking
 public extension Octokit {
     /// Deletes a reference.
     /// - Parameters:
-    ///   - session: RequestKitURLSession, defaults to URLSession.shared()
     ///   - owner: The user or organization that owns the repositories.
     ///   - repo: The repository on which the reference needs to be deleted.
     ///   - ref: The reference to delete.
     ///   - completion: Callback for the outcome of the deletion.
     @discardableResult
-    func deleteReference(_ session: RequestKitURLSession = URLSession.shared,
-                         owner: String,
+    func deleteReference(owner: String,
                          repository: String,
                          ref: String,
                          completion: @escaping (_ response: Error?) -> Void) -> URLSessionDataTaskProtocol? {

--- a/OctoKit/Issue.swift
+++ b/OctoKit/Issue.swift
@@ -83,15 +83,13 @@ public struct Comment: Codable {
 public extension Octokit {
     /**
      Fetches the issues of the authenticated user
-     - parameter session: RequestKitURLSession, defaults to URLSession.sharedSession()
      - parameter state: Issue state. Defaults to open if not specified.
      - parameter page: Current page for issue pagination. `1` by default.
      - parameter perPage: Number of issues per page. `100` by default.
      - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func myIssues(_ session: RequestKitURLSession = URLSession.shared,
-                  state: Openness = .open,
+    func myIssues(state: Openness = .open,
                   page: String = "1",
                   perPage: String = "100",
                   completion: @escaping (_ response: Result<[Issue], Error>) -> Void) -> URLSessionDataTaskProtocol? {
@@ -110,16 +108,13 @@ public extension Octokit {
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     /**
      Fetches the issues of the authenticated user
-     - parameter session: RequestKitURLSession, defaults to URLSession.sharedSession()
      - parameter state: Issue state. Defaults to open if not specified.
      - parameter page: Current page for issue pagination. `1` by default.
      - parameter perPage: Number of issues per page. `100` by default.
      - parameter completion: Callback for the outcome of the fetch.
      */
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func myIssues(_ session: RequestKitURLSession = URLSession.shared,
-                  state: Openness = .open,
+    func myIssues(state: Openness = .open,
                   page: String = "1",
                   perPage: String = "100") async throws -> [Issue] {
         let router = IssueRouter.readAuthenticatedIssues(configuration, page, perPage, state)
@@ -129,15 +124,13 @@ public extension Octokit {
 
     /**
      Fetches an issue in a repository
-     - parameter session: RequestKitURLSession, defaults to URLSession.sharedSession()
      - parameter owner: The user or organization that owns the repository.
      - parameter repository: The name of the repository.
      - parameter number: The number of the issue.
      - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func issue(_ session: RequestKitURLSession = URLSession.shared,
-               owner: String,
+    func issue(owner: String,
                repository: String,
                number: Int,
                completion: @escaping (_ response: Result<Issue, Error>) -> Void) -> URLSessionDataTaskProtocol? {
@@ -156,14 +149,13 @@ public extension Octokit {
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     /**
      Fetches an issue in a repository
-     - parameter session: RequestKitURLSession, defaults to URLSession.sharedSession()
      - parameter owner: The user or organization that owns the repository.
      - parameter repository: The name of the repository.
      - parameter number: The number of the issue.
      - parameter completion: Callback for the outcome of the fetch.
      */
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func issue(_ session: RequestKitURLSession = URLSession.shared, owner: String, repository: String, number: Int) async throws -> Issue {
+    func issue(owner: String, repository: String, number: Int) async throws -> Issue {
         let router = IssueRouter.readIssue(configuration, owner, repository, number)
         return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: Issue.self)
     }
@@ -171,7 +163,6 @@ public extension Octokit {
 
     /**
      Fetches all issues in a repository
-     - parameter session: RequestKitURLSession, defaults to URLSession.sharedSession()
      - parameter owner: The user or organization that owns the repository.
      - parameter repository: The name of the repository.
      - parameter state: Issue state. Defaults to open if not specified.
@@ -180,8 +171,7 @@ public extension Octokit {
      - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func issues(_ session: RequestKitURLSession = URLSession.shared,
-                owner: String,
+    func issues(owner: String,
                 repository: String,
                 state: Openness = .open,
                 page: String = "1",
@@ -202,7 +192,6 @@ public extension Octokit {
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     /**
      Fetches all issues in a repository
-     - parameter session: RequestKitURLSession, defaults to URLSession.sharedSession()
      - parameter owner: The user or organization that owns the repository.
      - parameter repository: The name of the repository.
      - parameter state: Issue state. Defaults to open if not specified.
@@ -211,8 +200,7 @@ public extension Octokit {
      - parameter completion: Callback for the outcome of the fetch.
      */
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func issues(_ session: RequestKitURLSession = URLSession.shared,
-                owner: String,
+    func issues(owner: String,
                 repository: String,
                 state: Openness = .open,
                 page: String = "1",
@@ -224,7 +212,6 @@ public extension Octokit {
 
     /**
      Creates an issue in a repository.
-     - parameter session: RequestKitURLSession, defaults to URLSession.sharedSession()
      - parameter owner: The user or organization that owns the repository.
      - parameter repository: The name of the repository.
      - parameter title: The title of the issue.
@@ -234,8 +221,7 @@ public extension Octokit {
      - parameter completion: Callback for the issue that is created.
      */
     @discardableResult
-    func postIssue(_ session: RequestKitURLSession = URLSession.shared,
-                   owner: String,
+    func postIssue(owner: String,
                    repository: String,
                    title: String,
                    body: String? = nil,
@@ -259,7 +245,6 @@ public extension Octokit {
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     /**
      Creates an issue in a repository.
-     - parameter session: RequestKitURLSession, defaults to URLSession.sharedSession()
      - parameter owner: The user or organization that owns the repository.
      - parameter repository: The name of the repository.
      - parameter title: The title of the issue.
@@ -268,8 +253,7 @@ public extension Octokit {
      - parameter labels: An array of label names to add to the issue. If the labels do not exist, GitHub will create them automatically. This parameter is ignored if the user lacks push access to the repository.
      */
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func postIssue(_ session: RequestKitURLSession = URLSession.shared,
-                   owner: String,
+    func postIssue(owner: String,
                    repository: String,
                    title: String,
                    body: String? = nil,
@@ -284,7 +268,6 @@ public extension Octokit {
 
     /**
      Edits an issue in a repository.
-     - parameter session: RequestKitURLSession, defaults to URLSession.sharedSession()
      - parameter owner: The user or organization that owns the repository.
      - parameter repository: The name of the repository.
      - parameter number: The number of the issue.
@@ -295,8 +278,7 @@ public extension Octokit {
      - parameter completion: Callback for the issue that is created.
      */
     @discardableResult
-    func patchIssue(_ session: RequestKitURLSession = URLSession.shared,
-                    owner: String,
+    func patchIssue(owner: String,
                     repository: String,
                     number: Int,
                     title: String? = nil,
@@ -319,7 +301,6 @@ public extension Octokit {
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     /**
      Edits an issue in a repository.
-     - parameter session: RequestKitURLSession, defaults to URLSession.sharedSession()
      - parameter owner: The user or organization that owns the repository.
      - parameter repository: The name of the repository.
      - parameter number: The number of the issue.
@@ -329,8 +310,7 @@ public extension Octokit {
      - parameter state: Whether the issue is open or closed.
      */
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func patchIssue(_ session: RequestKitURLSession = URLSession.shared,
-                    owner: String,
+    func patchIssue(owner: String,
                     repository: String,
                     number: Int,
                     title: String? = nil,
@@ -344,15 +324,13 @@ public extension Octokit {
 
     /// Posts a comment on an issue using the given body.
     /// - Parameters:
-    ///   - session: RequestKitURLSession, defaults to URLSession.sharedSession()
     ///   - owner: The user or organization that owns the repository.
     ///   - repository: The name of the repository.
     ///   - number: The number of the issue.
     ///   - body: The contents of the comment.
     ///   - completion: Callback for the comment that is created.
     @discardableResult
-    func commentIssue(_ session: RequestKitURLSession = URLSession.shared,
-                      owner: String,
+    func commentIssue(owner: String,
                       repository: String,
                       number: Int,
                       body: String,
@@ -374,14 +352,13 @@ public extension Octokit {
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     /// Posts a comment on an issue using the given body.
     /// - Parameters:
-    ///   - session: RequestKitURLSession, defaults to URLSession.sharedSession()
     ///   - owner: The user or organization that owns the repository.
     ///   - repository: The name of the repository.
     ///   - number: The number of the issue.
     ///   - body: The contents of the comment.
     ///   - completion: Callback for the comment that is created.
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func commentIssue(_ session: RequestKitURLSession = URLSession.shared, owner: String, repository: String, number: Int, body: String) async throws -> Comment {
+    func commentIssue(owner: String, repository: String, number: Int, body: String) async throws -> Comment {
         let router = IssueRouter.commentIssue(configuration, owner, repository, number, body)
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(Time.rfc3339DateFormatter)
@@ -391,16 +368,14 @@ public extension Octokit {
 
     /// Fetches all comments for an issue
     /// - Parameters:
-    /// - session: RequestKitURLSession, defaults to URLSession.sharedSession()
-    /// - owner: The user or organization that owns the repository.
-    /// - repository: The name of the repository.
-    /// - number: The number of the issue.
-    /// - page: Current page for comments pagination. `1` by default.
-    /// - perPage: Number of comments per page. `100` by default.
-    /// - completion: Callback for the outcome of the fetch.
+    ///   - owner: The user or organization that owns the repository.
+    ///   - repository: The name of the repository.
+    ///   - number: The number of the issue.
+    ///   - page: Current page for comments pagination. `1` by default.
+    ///   - perPage: Number of comments per page. `100` by default.
+    ///   - completion: Callback for the outcome of the fetch.
     @discardableResult
-    func issueComments(_ session: RequestKitURLSession = URLSession.shared,
-                       owner: String,
+    func issueComments(owner: String,
                        repository: String,
                        number: Int,
                        page: String = "1",
@@ -421,16 +396,14 @@ public extension Octokit {
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     /// Fetches all comments for an issue
     /// - Parameters:
-    /// - session: RequestKitURLSession, defaults to URLSession.sharedSession()
-    /// - owner: The user or organization that owns the repository.
-    /// - repository: The name of the repository.
-    /// - number: The number of the issue.
-    /// - page: Current page for comments pagination. `1` by default.
-    /// - perPage: Number of comments per page. `100` by default.
-    /// - completion: Callback for the outcome of the fetch.
+    ///   - owner: The user or organization that owns the repository.
+    ///   - repository: The name of the repository.
+    ///   - number: The number of the issue.
+    ///   - page: Current page for comments pagination. `1` by default.
+    ///   - perPage: Number of comments per page. `100` by default.
+    ///   - completion: Callback for the outcome of the fetch.
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func issueComments(_ session: RequestKitURLSession = URLSession.shared,
-                       owner: String,
+    func issueComments(owner: String,
                        repository: String,
                        number: Int,
                        page: String = "1",
@@ -442,15 +415,13 @@ public extension Octokit {
 
     /// Edits a comment on an issue using the given body.
     /// - Parameters:
-    ///   - session: RequestKitURLSession, defaults to URLSession.sharedSession()
     ///   - owner: The user or organization that owns the repository.
     ///   - repository: The name of the repository.
     ///   - number: The number of the comment.
     ///   - body: The contents of the comment.
     ///   - completion: Callback for the comment that is created.
     @discardableResult
-    func patchIssueComment(_ session: RequestKitURLSession = URLSession.shared,
-                           owner: String,
+    func patchIssueComment(owner: String,
                            repository: String,
                            number: Int,
                            body: String,
@@ -472,14 +443,13 @@ public extension Octokit {
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     /// Edits a comment on an issue using the given body.
     /// - Parameters:
-    ///   - session: RequestKitURLSession, defaults to URLSession.sharedSession()
     ///   - owner: The user or organization that owns the repository.
     ///   - repository: The name of the repository.
     ///   - number: The number of the comment.
     ///   - body: The contents of the comment.
     ///   - completion: Callback for the comment that is created.
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func patchIssueComment(_ session: RequestKitURLSession = URLSession.shared, owner: String, repository: String, number: Int, body: String) async throws -> Comment {
+    func patchIssueComment(owner: String, repository: String, number: Int, body: String) async throws -> Comment {
         let router = IssueRouter.patchIssueComment(configuration, owner, repository, number, body)
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(Time.rfc3339DateFormatter)

--- a/OctoKit/Label.swift
+++ b/OctoKit/Label.swift
@@ -15,15 +15,13 @@ open class Label: Codable {
 public extension Octokit {
     /**
       Fetches a single label in a repository
-      - parameter session: RequestKitURLSession, defaults to URLSession.sharedSession()
       - parameter owner: The user or organization that owns the repository.
       - parameter repository: The name of the repository.
       - parameter name: The name of the label.
       - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func label(_ session: RequestKitURLSession = URLSession.shared,
-               owner: String,
+    func label(owner: String,
                repository: String,
                name: String,
                completion: @escaping (_ response: Result<Label, Error>) -> Void) -> URLSessionDataTaskProtocol? {
@@ -42,13 +40,12 @@ public extension Octokit {
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     /**
       Fetches a single label in a repository
-      - parameter session: RequestKitURLSession, defaults to URLSession.sharedSession()
       - parameter owner: The user or organization that owns the repository.
       - parameter repository: The name of the repository.
       - parameter name: The name of the label.
      */
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func label(_ session: RequestKitURLSession = URLSession.shared, owner: String, repository: String, name: String) async throws -> Label {
+    func label(owner: String, repository: String, name: String) async throws -> Label {
         let router = LabelRouter.readLabel(configuration, owner, repository, name)
         return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: Label.self)
     }
@@ -56,7 +53,6 @@ public extension Octokit {
 
     /**
      Fetches all labels in a repository
-     - parameter session: RequestKitURLSession, defaults to URLSession.sharedSession()
      - parameter owner: The user or organization that owns the repository.
      - parameter repository: The name of the repository.
      - parameter page: Current page for label pagination. `1` by default.
@@ -64,8 +60,7 @@ public extension Octokit {
      - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func labels(_ session: RequestKitURLSession = URLSession.shared,
-                owner: String,
+    func labels(owner: String,
                 repository: String,
                 page: String = "1",
                 perPage: String = "100",
@@ -85,14 +80,13 @@ public extension Octokit {
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     /**
      Fetches all labels in a repository
-     - parameter session: RequestKitURLSession, defaults to URLSession.sharedSession()
      - parameter owner: The user or organization that owns the repository.
      - parameter repository: The name of the repository.
      - parameter page: Current page for label pagination. `1` by default.
      - parameter perPage: Number of labels per page. `100` by default.
      */
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func labels(_ session: RequestKitURLSession = URLSession.shared, owner: String, repository: String, page: String = "1", perPage: String = "100") async throws -> [Label] {
+    func labels(owner: String, repository: String, page: String = "1", perPage: String = "100") async throws -> [Label] {
         let router = LabelRouter.readLabels(configuration, owner, repository, page, perPage)
         return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Label].self)
     }
@@ -100,7 +94,6 @@ public extension Octokit {
 
     /**
      Create a label in a repository
-     - parameter session: RequestKitURLSession, defaults to URLSession.sharedSession()
      - parameter owner: The user or organization that owns the repository.
      - parameter repository: The name of the repository.
      - parameter name: The name of the label.
@@ -108,8 +101,7 @@ public extension Octokit {
      - parameter completion: Callback for the outcome of the request.
      */
     @discardableResult
-    func postLabel(_ session: RequestKitURLSession = URLSession.shared,
-                   owner: String,
+    func postLabel(owner: String,
                    repository: String,
                    name: String,
                    color: String,
@@ -129,14 +121,13 @@ public extension Octokit {
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     /**
      Create a label in a repository
-     - parameter session: RequestKitURLSession, defaults to URLSession.sharedSession()
      - parameter owner: The user or organization that owns the repository.
      - parameter repository: The name of the repository.
      - parameter name: The name of the label.
      - parameter color: The color of the label, in hexadecimal without the leading `#`.
      */
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func postLabel(_ session: RequestKitURLSession = URLSession.shared, owner: String, repository: String, name: String, color: String) async throws -> Label {
+    func postLabel(owner: String, repository: String, name: String, color: String) async throws -> Label {
         let router = LabelRouter.createLabel(configuration, owner, repository, name, color)
         return try await router.post(session, expectedResultType: Label.self)
     }

--- a/OctoKit/NotificationThread.swift
+++ b/OctoKit/NotificationThread.swift
@@ -78,7 +78,6 @@ open class ThreadSubscription: Codable {
 public extension Octokit {
     /**
      List all notifications for the current user, sorted by most recently updated.
-     - parameter session: RequestKitURLSession, defaults to URLSession.shared
      - parameter all: show notifications marked as read `false` by default.
      - parameter participating: only shows notifications in which the user is directly participating or mentioned. `false` by default.
      - parameter page: Current page for notification pagination. `1` by default.
@@ -86,8 +85,7 @@ public extension Octokit {
      - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func myNotifications(_ session: RequestKitURLSession = URLSession.shared,
-                         all: Bool = false,
+    func myNotifications(all: Bool = false,
                          participating: Bool = false,
                          page: String = "1",
                          perPage: String = "100",
@@ -106,14 +104,12 @@ public extension Octokit {
 
     /**
      Marks All Notifications As read
-     - parameter session: RequestKitURLSession, defaults to URLSession.shared
      - parameter lastReadAt: Describes the last point that notifications were checked `last_read_at` by default.
      - parameter read: Whether the notification has been read `false` by default.
      - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func markNotificationsRead(_ session: RequestKitURLSession = URLSession.shared,
-                               lastReadAt: String = "last_read_at",
+    func markNotificationsRead(lastReadAt: String = "last_read_at",
                                read: Bool = false,
                                completion: @escaping (_ response: Error?) -> Void) -> URLSessionDataTaskProtocol? {
         let router = NotificationRouter.markNotificationsRead(configuration, lastReadAt, read)
@@ -122,13 +118,11 @@ public extension Octokit {
 
     /**
      Marks All Notifications As read
-     - parameter session: RequestKitURLSession, defaults to URLSession.shared
      - parameter threadId: The ID of the Thread.
      - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func getNotificationThread(_ session: RequestKitURLSession = URLSession.shared,
-                               threadId: String,
+    func getNotificationThread(threadId: String,
                                completion: @escaping (_ response: Result<NotificationThread, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = NotificationRouter.getNotificationThread(configuration, threadId)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: NotificationThread.self) { notification, error in
@@ -144,13 +138,11 @@ public extension Octokit {
 
     /**
      Get a thread subscription for the authenticated user
-      - parameter session: RequestKitURLSession, defaults to URLSession.shared
       - parameter threadId: The ID of the Thread.
       - parameter completion: Callback for the outcome of the fetch.
       */
     @discardableResult
-    func getThreadSubscription(_ session: RequestKitURLSession = URLSession.shared,
-                               threadId: String,
+    func getThreadSubscription(threadId: String,
                                completion: @escaping (_ response: Result<ThreadSubscription, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = NotificationRouter.getThreadSubscription(configuration, threadId)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: ThreadSubscription.self) { thread, error in
@@ -166,14 +158,12 @@ public extension Octokit {
 
     /**
      Sets a thread subscription for the authenticated user
-     - parameter session: RequestKitURLSession, defaults to URLSession.shared
      - parameter threadId: The ID of the Thread.
      - parameter ignored: Whether to block all notifications from a thread `false` by default.
      - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func setThreadSubscription(_ session: RequestKitURLSession = URLSession.shared,
-                               threadId: String,
+    func setThreadSubscription(threadId: String,
                                ignored: Bool = false,
                                completion: @escaping (_ response: Result<ThreadSubscription, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = NotificationRouter.setThreadSubscription(configuration, threadId, ignored)
@@ -190,19 +180,17 @@ public extension Octokit {
 
     /**
      Delete a thread subscription
-     - parameter session: RequestKitURLSession, defaults to URLSession.shared
      - parameter threadId: The ID of the Thread.
      - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func deleteThreadSubscription(_ session: RequestKitURLSession = URLSession.shared, threadId: String, completion: @escaping (_ response: Error?) -> Void) -> URLSessionDataTaskProtocol? {
+    func deleteThreadSubscription(threadId: String, completion: @escaping (_ response: Error?) -> Void) -> URLSessionDataTaskProtocol? {
         let router = NotificationRouter.deleteThreadSubscription(configuration, threadId)
         return router.load(session, completion: completion)
     }
 
     /**
      List all repository notifications for the current user, sorted by most recently updated.
-     - parameter session: RequestKitURLSession, defaults to URLSession.shared
      - parameter owner: The name of the owner of the repository.
      - parameter repository: The name of the repository.
      - parameter all: show notifications marked as read `false` by default.
@@ -214,8 +202,7 @@ public extension Octokit {
      - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func listRepositoryNotifications(_ session: RequestKitURLSession = URLSession.shared,
-                                     owner: String,
+    func listRepositoryNotifications(owner: String,
                                      repository: String,
                                      all: Bool = false,
                                      participating: Bool = false,
@@ -238,15 +225,13 @@ public extension Octokit {
 
     /**
      Marks All Repository Notifications As read
-     - parameter session: RequestKitURLSession, defaults to URLSession.sharedSession()
      - parameter owner: The name of the owner of the repository.
      - parameter repository: The name of the repository.
      - parameter lastReadAt: Describes the last point that notifications were checked `last_read_at` by default.
      - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func markRepositoryNotificationsRead(_ session: RequestKitURLSession = URLSession.shared,
-                                         owner: String,
+    func markRepositoryNotificationsRead(owner: String,
                                          repository: String,
                                          lastReadAt: String? = nil,
                                          completion: @escaping (_ response: Error?) -> Void) -> URLSessionDataTaskProtocol? {

--- a/OctoKit/Octokit.swift
+++ b/OctoKit/Octokit.swift
@@ -1,9 +1,15 @@
 import Foundation
+import RequestKit
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 public struct Octokit {
     public let configuration: TokenConfiguration
+    public let session: RequestKitURLSession
 
-    public init(_ config: TokenConfiguration = TokenConfiguration()) {
+    public init(_ config: TokenConfiguration = TokenConfiguration(), session: RequestKitURLSession = URLSession.shared) {
         configuration = config
+        self.session = session
     }
 }

--- a/OctoKit/PublicKey.swift
+++ b/OctoKit/PublicKey.swift
@@ -7,8 +7,7 @@ import FoundationNetworking
 // MARK: request
 
 public extension Octokit {
-    func postPublicKey(_ session: RequestKitURLSession = URLSession.shared,
-                       publicKey: String,
+    func postPublicKey(publicKey: String,
                        title: String,
                        completion: @escaping (_ response: Result<String, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = PublicKeyRouter.postPublicKey(publicKey, title, configuration)
@@ -25,7 +24,7 @@ public extension Octokit {
 
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func postPublicKey(_ session: RequestKitURLSession = URLSession.shared, publicKey: String, title: String) async throws -> String {
+    func postPublicKey(publicKey: String, title: String) async throws -> String {
         let router = PublicKeyRouter.postPublicKey(publicKey, title, configuration)
         _ = try await router.postJSON(session, expectedResultType: [String: AnyObject].self)
         return publicKey

--- a/OctoKit/PullRequest.swift
+++ b/OctoKit/PullRequest.swift
@@ -85,7 +85,6 @@ open class PullRequest: Codable {
 public extension Octokit {
     /**
      Create a pull request
-     - parameter session: RequestKitURLSession, defaults to URLSession.shared
      - parameter owner: The user or organization that owns the repositories.
      - parameter repo: The name of the repository.
      - parameter title: The title of the new pull request.
@@ -98,8 +97,7 @@ public extension Octokit {
      - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func createPullRequest(_ session: RequestKitURLSession = URLSession.shared,
-                           owner: String,
+    func createPullRequest(owner: String,
                            repo: String,
                            title: String,
                            head: String,
@@ -126,7 +124,6 @@ public extension Octokit {
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     /**
      Create a pull request
-     - parameter session: RequestKitURLSession, defaults to URLSession.shared
      - parameter owner: The user or organization that owns the repositories.
      - parameter repo: The name of the repository.
      - parameter title: The title of the new pull request.
@@ -139,8 +136,7 @@ public extension Octokit {
      - Returns: A PullRequest
      */
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func createPullRequest(_ session: RequestKitURLSession = URLSession.shared,
-                           owner: String,
+    func createPullRequest(owner: String,
                            repo: String,
                            title: String,
                            head: String,
@@ -158,15 +154,13 @@ public extension Octokit {
 
     /**
      Get a single pull request
-     - parameter session: RequestKitURLSession, defaults to URLSession.shared
      - parameter owner: The user or organization that owns the repositories.
      - parameter repository: The name of the repository.
      - parameter number: The number of the PR to fetch.
      - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func pullRequest(_ session: RequestKitURLSession = URLSession.shared,
-                     owner: String,
+    func pullRequest(owner: String,
                      repository: String,
                      number: Int,
                      completion: @escaping (_ response: Result<PullRequest, Error>) -> Void) -> URLSessionDataTaskProtocol? {
@@ -185,14 +179,12 @@ public extension Octokit {
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     /**
      Get a single pull request
-     - parameter session: RequestKitURLSession, defaults to URLSession.shared
      - parameter owner: The user or organization that owns the repositories.
      - parameter repository: The name of the repository.
      - parameter number: The number of the PR to fetch.
      */
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func pullRequest(_ session: RequestKitURLSession = URLSession.shared,
-                     owner: String,
+    func pullRequest(owner: String,
                      repository: String,
                      number: Int) async throws -> PullRequest {
         let router = PullRequestRouter.readPullRequest(configuration, owner, repository, "\(number)")
@@ -202,7 +194,6 @@ public extension Octokit {
 
     /**
      Get a list of pull requests
-     - parameter session: RequestKitURLSession, defaults to URLSession.shared
      - parameter owner: The user or organization that owns the repositories.
      - parameter repository: The name of the repository.
      - parameter base: Filter pulls by base branch name.
@@ -212,8 +203,7 @@ public extension Octokit {
      - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func pullRequests(_ session: RequestKitURLSession = URLSession.shared,
-                      owner: String,
+    func pullRequests(owner: String,
                       repository: String,
                       base: String? = nil,
                       head: String? = nil,
@@ -236,7 +226,6 @@ public extension Octokit {
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     /**
      Get a list of pull requests
-     - parameter session: RequestKitURLSession, defaults to URLSession.shared
      - parameter owner: The user or organization that owns the repositories.
      - parameter repository: The name of the repository.
      - parameter base: Filter pulls by base branch name.
@@ -245,8 +234,7 @@ public extension Octokit {
      - parameter direction: The direction of the sort.
      */
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func pullRequests(_ session: RequestKitURLSession = URLSession.shared,
-                      owner: String,
+    func pullRequests(owner: String,
                       repository: String,
                       base: String? = nil,
                       head: String? = nil,
@@ -260,7 +248,6 @@ public extension Octokit {
 
     /**
      Updates a pull request
-     - parameter session: RequestKitURLSession, defaults to URLSession.shared
      - parameter owner: The user or organization that owns the repositories.
      - parameter repository: The name of the repository.
      - parameter number: The number of the PR to update.
@@ -272,8 +259,7 @@ public extension Octokit {
      - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func patchPullRequest(_ session: RequestKitURLSession = URLSession.shared,
-                          owner: String,
+    func patchPullRequest(owner: String,
                           repository: String,
                           number: Int,
                           title: String,
@@ -300,7 +286,6 @@ public extension Octokit {
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     /**
      Updates a pull request
-     - parameter session: RequestKitURLSession, defaults to URLSession.shared
      - parameter owner: The user or organization that owns the repositories.
      - parameter repository: The name of the repository.
      - parameter number: The number of the PR to update.
@@ -311,8 +296,7 @@ public extension Octokit {
      - parameter mantainerCanModify: The new baseBranch of the PR
      */
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func patchPullRequest(_ session: RequestKitURLSession = URLSession.shared,
-                          owner: String,
+    func patchPullRequest(owner: String,
                           repository: String,
                           number: Int,
                           title: String,

--- a/OctoKit/Releases.swift
+++ b/OctoKit/Releases.swift
@@ -52,14 +52,12 @@ public struct Release: Codable {
 public extension Octokit {
     /// Fetches the list of releases.
     /// - Parameters:
-    ///   - session: RequestKitURLSession, defaults to URLSession.shared()
     ///   - owner: The user or organization that owns the repositories.
     ///   - repository: The name of the repository.
     ///   - perPage: Results per page (max 100). Default: `30`.
     ///   - completion: Callback for the outcome of the fetch.
     @discardableResult
-    func listReleases(_ session: RequestKitURLSession = URLSession.shared,
-                      owner: String,
+    func listReleases(owner: String,
                       repository: String,
                       perPage: Int = 30,
                       completion: @escaping (_ response: Result<[Release], Error>) -> Void) -> URLSessionDataTaskProtocol? {
@@ -76,11 +74,11 @@ public extension Octokit {
     }
 
     /// Fetches a published release with the specified tag.
+    /// - Parameters:
     ///   - tag: The specified tag
     ///   - completion: Callback for the outcome of the fetch.
     @discardableResult
-    func release(_ session: RequestKitURLSession = URLSession.shared,
-                 owner: String,
+    func release(owner: String,
                  repository: String,
                  tag: String,
                  completion: @escaping (_ response: Result<Release, Error>) -> Void) -> URLSessionDataTaskProtocol? {
@@ -99,23 +97,21 @@ public extension Octokit {
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     /// Fetches the list of releases.
     /// - Parameters:
-    ///   - session: RequestKitURLSession, defaults to URLSession.shared()
     ///   - owner: The user or organization that owns the repositories.
     ///   - repository: The name of the repository.
     ///   - perPage: Results per page (max 100). Default: `30`.2
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func listReleases(_ session: RequestKitURLSession = URLSession.shared, owner: String, repository: String, perPage: Int = 30) async throws -> [Release] {
+    func listReleases(owner: String, repository: String, perPage: Int = 30) async throws -> [Release] {
         let router = ReleaseRouter.listReleases(configuration, owner, repository, perPage)
         return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Release].self)
     }
 
     /// Fetches the latest release.
     /// - Parameters:
-    ///   - session: RequestKitURLSession, defaults to URLSession.shared()
     ///   - owner: The user or organization that owns the repositories.
     ///   - repository: The name of the repository.
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func getLatestRelease(_ session: RequestKitURLSession = URLSession.shared, owner: String, repository: String) async throws -> Release {
+    func getLatestRelease(owner: String, repository: String) async throws -> Release {
         let router = ReleaseRouter.getLatestRelease(configuration, owner, repository)
         return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: Release.self)
     }
@@ -123,7 +119,6 @@ public extension Octokit {
 
     /// Creates a new release.
     /// - Parameters:
-    ///   - session: RequestKitURLSession, defaults to URLSession.shared()
     ///   - owner: The user or organization that owns the repositories.
     ///   - repo: The repository on which the release needs to be created.
     ///   - tagName: The name of the tag.
@@ -134,8 +129,7 @@ public extension Octokit {
     ///   - draft: `true` to identify the release as a prerelease. `false` to identify the release as a full release. Default: `false`.
     ///   - completion: Callback for the outcome of the created release.
     @discardableResult
-    func postRelease(_ session: RequestKitURLSession = URLSession.shared,
-                     owner: String,
+    func postRelease(owner: String,
                      repository: String,
                      tagName: String,
                      targetCommitish: String? = nil,
@@ -162,14 +156,12 @@ public extension Octokit {
 
     /// Deletes a release.
     /// - Parameters:
-    ///   - session: RequestKitURLSession, defaults to URLSession.shared()
     ///   - owner: The user or organization that owns the repositories.
     ///   - repo: The repository on which the release needs to be deleted.
     ///   - releaseId: The ID of the release to delete.
     ///   - completion: Callback for the outcome of the deletion.
     @discardableResult
-    func deleteRelease(_ session: RequestKitURLSession = URLSession.shared,
-                       owner: String,
+    func deleteRelease(owner: String,
                        repository: String,
                        releaseId: Int,
                        completion: @escaping (_ response: Error?) -> Void) -> URLSessionDataTaskProtocol? {
@@ -180,7 +172,6 @@ public extension Octokit {
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     /// Creates a new release.
     /// - Parameters:
-    ///   - session: RequestKitURLSession, defaults to URLSession.shared()
     ///   - owner: The user or organization that owns the repositories.
     ///   - repo: The repository on which the release needs to be created.
     ///   - tagName: The name of the tag.
@@ -190,8 +181,7 @@ public extension Octokit {
     ///   - prerelease: `true` to create a draft (unpublished) release, `false` to create a published one. Default: `false`.
     ///   - draft: `true` to identify the release as a prerelease. `false` to identify the release as a full release. Default: `false`.
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func postRelease(_ session: RequestKitURLSession = URLSession.shared,
-                     owner: String,
+    func postRelease(owner: String,
                      repository: String,
                      tagName: String,
                      targetCommitish: String? = nil,

--- a/OctoKit/Repositories.swift
+++ b/OctoKit/Repositories.swift
@@ -45,15 +45,13 @@ open class Repository: Codable {
 public extension Octokit {
     /**
          Fetches the Repositories for a user or organization
-         - parameter session: RequestKitURLSession, defaults to URLSession.shared
          - parameter owner: The user or organization that owns the repositories. If `nil`, fetches repositories for the authenticated user.
          - parameter page: Current page for repository pagination. `1` by default.
          - parameter perPage: Number of repositories per page. `100` by default.
          - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func repositories(_ session: RequestKitURLSession = URLSession.shared,
-                      owner: String? = nil,
+    func repositories(owner: String? = nil,
                       page: String = "1",
                       perPage: String = "100",
                       completion: @escaping (_ response: Result<[Repository], Error>) -> Void) -> URLSessionDataTaskProtocol? {
@@ -74,13 +72,12 @@ public extension Octokit {
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     /**
          Fetches the Repositories for a user or organization
-         - parameter session: RequestKitURLSession, defaults to URLSession.shared
          - parameter owner: The user or organization that owns the repositories. If `nil`, fetches repositories for the authenticated user.
          - parameter page: Current page for repository pagination. `1` by default.
          - parameter perPage: Number of repositories per page. `100` by default.
      */
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func repositories(_ session: RequestKitURLSession = URLSession.shared, owner: String? = nil, page: String = "1", perPage: String = "100") async throws -> [Repository] {
+    func repositories(owner: String? = nil, page: String = "1", perPage: String = "100") async throws -> [Repository] {
         let router = (owner != nil)
             ? RepositoryRouter.readRepositories(configuration, owner!, page, perPage)
             : RepositoryRouter.readAuthenticatedRepositories(configuration, page, perPage)
@@ -90,14 +87,12 @@ public extension Octokit {
 
     /**
          Fetches a repository for a user or organization
-         - parameter session: RequestKitURLSession, defaults to URLSession.shared
          - parameter owner: The user or organization that owns the repositories.
          - parameter name: The name of the repository to fetch.
          - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func repository(_ session: RequestKitURLSession = URLSession.shared,
-                    owner: String,
+    func repository(owner: String,
                     name: String,
                     completion: @escaping (_ response: Result<Repository, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = RepositoryRouter.readRepository(configuration, owner, name)
@@ -115,12 +110,11 @@ public extension Octokit {
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     /**
          Fetches a repository for a user or organization
-         - parameter session: RequestKitURLSession, defaults to URLSession.shared
          - parameter owner: The user or organization that owns the repositories.
          - parameter name: The name of the repository to fetch.
      */
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func repository(_ session: RequestKitURLSession = URLSession.shared, owner: String, name: String) async throws -> Repository {
+    func repository(owner: String, name: String) async throws -> Repository {
         let router = RepositoryRouter.readRepository(configuration, owner, name)
         return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: Repository.self)
     }

--- a/OctoKit/Review.swift
+++ b/OctoKit/Review.swift
@@ -67,8 +67,7 @@ extension Review.Comment {
 
 public extension Octokit {
     @discardableResult
-    func listReviews(_ session: RequestKitURLSession = URLSession.shared,
-                     owner: String,
+    func listReviews(owner: String,
                      repository: String,
                      pullRequestNumber: Int,
                      completion: @escaping (_ response: Result<[Review], Error>) -> Void) -> URLSessionDataTaskProtocol? {
@@ -85,8 +84,7 @@ public extension Octokit {
     }
 
     @discardableResult
-    func postReview(_ session: RequestKitURLSession = URLSession.shared,
-                    owner: String,
+    func postReview(owner: String,
                     repository: String,
                     pullRequestNumber: Int,
                     commitId: String? = nil,
@@ -106,8 +104,7 @@ public extension Octokit {
 
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func reviews(_ session: RequestKitURLSession = URLSession.shared,
-                 owner: String,
+    func reviews(owner: String,
                  repository: String,
                  pullRequestNumber: Int) async throws -> [Review] {
         let router = ReviewsRouter.listReviews(configuration, owner, repository, pullRequestNumber)
@@ -116,8 +113,7 @@ public extension Octokit {
 
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     @discardableResult
-    func postReview(_ session: RequestKitURLSession = URLSession.shared,
-                    owner: String,
+    func postReview(owner: String,
                     repository: String,
                     pullRequestNumber: Int,
                     commitId: String? = nil,

--- a/OctoKit/Stars.swift
+++ b/OctoKit/Stars.swift
@@ -6,13 +6,12 @@ import FoundationNetworking
 
 public extension Octokit {
     /**
-         Fetches all the starred repositories for a user
-         - parameter session: RequestKitURLSession, defaults to URLSession.shared
-         - parameter name: The user who starred repositories.
-         - parameter completion: Callback for the outcome of the fetch.
+     Fetches all the starred repositories for a user
+     - parameter name: The user who starred repositories.
+     - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func stars(_ session: RequestKitURLSession = URLSession.shared, name: String, completion: @escaping (_ response: Result<[Repository], Error>) -> Void) -> URLSessionDataTaskProtocol? {
+    func stars(name: String, completion: @escaping (_ response: Result<[Repository], Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = StarsRouter.readStars(name, configuration)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Repository].self) { repos, error in
             if let error = error {
@@ -27,11 +26,10 @@ public extension Octokit {
 
     /**
          Fetches all the starred repositories for the authenticated user
-         - parameter session: RequestKitURLSession, defaults to URLSession.shared
          - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func myStars(_ session: RequestKitURLSession = URLSession.shared, completion: @escaping (_ response: Result<[Repository], Error>) -> Void) -> URLSessionDataTaskProtocol? {
+    func myStars(completion: @escaping (_ response: Result<[Repository], Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = StarsRouter.readAuthenticatedStars(configuration)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Repository].self) { repos, error in
             if let error = error {
@@ -46,14 +44,12 @@ public extension Octokit {
 
     /**
      Checks if a repository is starred by the authenticated user
-     - parameter session: RequestKitURLSession, defaults to URLSession.sharedSession()
      - parameter owner: The name of the owner of the repository.
      - parameter repository: The name of the repository.
      - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func star(_ session: RequestKitURLSession = URLSession.shared,
-              owner: String,
+    func star(owner: String,
               repository: String,
               completion: @escaping (_ response: Result<Bool, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = StarsRouter.readStar(configuration, owner, repository)
@@ -72,14 +68,12 @@ public extension Octokit {
 
     /**
      Stars a repository for the authenticated user
-     - parameter session: RequestKitURLSession, defaults to URLSession.sharedSession()
      - parameter owner: The name of the owner of the repository.
      - parameter repository: The name of the repository.
      - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func putStar(_ session: RequestKitURLSession = URLSession.shared,
-                 owner: String,
+    func putStar(owner: String,
                  repository: String,
                  completion: @escaping (_ response: Error?) -> Void) -> URLSessionDataTaskProtocol? {
         let router = StarsRouter.putStar(configuration, owner, repository)
@@ -88,14 +82,12 @@ public extension Octokit {
 
     /**
      Unstars a repository for the authenticated user
-     - parameter session: RequestKitURLSession, defaults to URLSession.sharedSession()
      - parameter owner: The name of the owner of the repository.
      - parameter repository: The name of the repository.
      - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func deleteStar(_ session: RequestKitURLSession = URLSession.shared,
-                    owner: String,
+    func deleteStar(owner: String,
                     repository: String,
                     completion: @escaping (_ response: Error?) -> Void) -> URLSessionDataTaskProtocol? {
         let router = StarsRouter.deleteStar(configuration, owner, repository)
@@ -108,33 +100,29 @@ public extension Octokit {
 public extension Octokit {
     /**
      Fetches all the starred repositories for a user
-     - parameter session: RequestKitURLSession, defaults to URLSession.shared
      - parameter name: The user who starred repositories.
      */
-    func stars(_ session: RequestKitURLSession = URLSession.shared, name: String) async throws -> [Repository] {
+    func stars(name: String) async throws -> [Repository] {
         let router = StarsRouter.readStars(name, configuration)
         return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Repository].self)
     }
 
     /**
      Fetches all the starred repositories for the authenticated user
-     - parameter session: RequestKitURLSession, defaults to URLSession.shared
      - Returns: The repos which the authenticated user stars.
      */
-    func myStars(_ session: RequestKitURLSession = URLSession.shared) async throws -> [Repository] {
+    func myStars() async throws -> [Repository] {
         let router = StarsRouter.readAuthenticatedStars(configuration)
         return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Repository].self)
     }
 
     /**
      Checks if a repository is starred by the authenticated user
-     - parameter session: RequestKitURLSession, defaults to URLSession.sharedSession()
      - parameter owner: The name of the owner of the repository.
      - parameter repository: The name of the repository.
      - Returns: If the repository is starred by the authenticated user
      */
-    func star(_ session: RequestKitURLSession = URLSession.shared,
-              owner: String,
+    func star(owner: String,
               repository: String) async throws -> Bool {
         let router = StarsRouter.readStar(configuration, owner, repository)
         do {
@@ -149,12 +137,10 @@ public extension Octokit {
 
     /**
      Stars a repository for the authenticated user
-     - parameter session: RequestKitURLSession, defaults to URLSession.sharedSession()
      - parameter owner: The name of the owner of the repository.
      - parameter repository: The name of the repository.
      */
-    func putStar(_ session: RequestKitURLSession = URLSession.shared,
-                 owner: String,
+    func putStar(owner: String,
                  repository: String) async throws {
         let router = StarsRouter.putStar(configuration, owner, repository)
         try await router.load(session)
@@ -162,12 +148,10 @@ public extension Octokit {
 
     /**
      Unstars a repository for the authenticated user
-     - parameter session: RequestKitURLSession, defaults to URLSession.sharedSession()
      - parameter owner: The name of the owner of the repository.
      - parameter repository: The name of the repository.
      */
-    func deleteStar(_ session: RequestKitURLSession = URLSession.shared,
-                    owner: String,
+    func deleteStar(owner: String,
                     repository: String) async throws {
         let router = StarsRouter.deleteStar(configuration, owner, repository)
         try await router.load(session)

--- a/OctoKit/Statuses.swift
+++ b/OctoKit/Statuses.swift
@@ -46,7 +46,6 @@ open class Status: Codable {
 public extension Octokit {
     /**
      Creates a commit status
-     - parameter session: RequestKitURLSession, defaults to URLSession.sharedSession()
      - parameter owner: The user or organization that owns the repository.
      - parameter repository: The name of the repository.
      - parameter sha: The commit SHA.
@@ -57,8 +56,7 @@ public extension Octokit {
      - parameter completion: Callback for the outcome of the request.
      */
     @discardableResult
-    func createCommitStatus(_ session: RequestKitURLSession = URLSession.shared,
-                            owner: String,
+    func createCommitStatus(owner: String,
                             repository: String,
                             sha: String,
                             state: Status.State,
@@ -83,7 +81,6 @@ public extension Octokit {
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     /**
      Creates a commit status
-     - parameter session: RequestKitURLSession, defaults to URLSession.sharedSession()
      - parameter owner: The user or organization that owns the repository.
      - parameter repository: The name of the repository.
      - parameter sha: The commit SHA.
@@ -93,8 +90,7 @@ public extension Octokit {
      - parameter context: A string label to differentiate this status from the status of other systems.
      */
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func createCommitStatus(_ session: RequestKitURLSession = URLSession.shared,
-                            owner: String,
+    func createCommitStatus(owner: String,
                             repository: String,
                             sha: String,
                             state: Status.State,
@@ -110,15 +106,13 @@ public extension Octokit {
 
     /**
      Fetches commit statuses for a reference
-     - parameter session: RequestKitURLSession, defaults to URLSession.sharedSession()
      - parameter owner: The user or organization that owns the repository.
      - parameter repository: The name of the repository.
      - parameter ref: SHA, a branch name, or a tag name.
      - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func listCommitStatuses(_ session: RequestKitURLSession = URLSession.shared,
-                            owner: String,
+    func listCommitStatuses(owner: String,
                             repository: String,
                             ref: String,
                             completion: @escaping (_ response: Result<[Status], Error>) -> Void) -> URLSessionDataTaskProtocol? {
@@ -137,14 +131,12 @@ public extension Octokit {
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     /**
      Fetches commit statuses for a reference
-     - parameter session: RequestKitURLSession, defaults to URLSession.sharedSession()
      - parameter owner: The user or organization that owns the repository.
      - parameter repository: The name of the repository.
      - parameter ref: SHA, a branch name, or a tag name.
      */
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func listCommitStatuses(_ session: RequestKitURLSession = URLSession.shared,
-                            owner: String,
+    func listCommitStatuses(owner: String,
                             repository: String,
                             ref: String) async throws -> [Status] {
         let router = StatusesRouter.listCommitStatuses(configuration, owner: owner, repo: repository, ref: ref)

--- a/OctoKit/User.swift
+++ b/OctoKit/User.swift
@@ -92,13 +92,12 @@ open class User: Codable {
 
 public extension Octokit {
     /**
-         Fetches a user or organization
-         - parameter session: RequestKitURLSession, defaults to URLSession.shared
-         - parameter name: The name of the user or organization.
-         - parameter completion: Callback for the outcome of the fetch.
+     Fetches a user or organization
+     - parameter name: The name of the user or organization.
+     - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func user(_ session: RequestKitURLSession = URLSession.shared, name: String, completion: @escaping (_ response: Result<User, Error>) -> Void) -> URLSessionDataTaskProtocol? {
+    func user(name: String, completion: @escaping (_ response: Result<User, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = UserRouter.readUser(name, configuration)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: User.self) { user, error in
             if let error = error {
@@ -113,24 +112,22 @@ public extension Octokit {
 
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     /**
-         Fetches a user or organization
-         - parameter session: RequestKitURLSession, defaults to URLSession.shared
-         - parameter name: The name of the user or organization.
+     Fetches a user or organization
+     - parameter name: The name of the user or organization.
      */
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func user(_ session: RequestKitURLSession = URLSession.shared, name: String) async throws -> User {
+    func user(name: String) async throws -> User {
         let router = UserRouter.readUser(name, configuration)
         return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: User.self)
     }
     #endif
 
     /**
-         Fetches the authenticated user
-         - parameter session: RequestKitURLSession, defaults to URLSession.shared
-         - parameter completion: Callback for the outcome of the fetch.
+     Fetches the authenticated user
+     - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func me(_ session: RequestKitURLSession = URLSession.shared, completion: @escaping (_ response: Result<User, Error>) -> Void) -> URLSessionDataTaskProtocol? {
+    func me(completion: @escaping (_ response: Result<User, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = UserRouter.readAuthenticatedUser(configuration)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: User.self) { user, error in
             if let error = error {
@@ -145,11 +142,10 @@ public extension Octokit {
 
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     /**
-         Fetches the authenticated user
-         - parameter session: RequestKitURLSession, defaults to URLSession.shared
+     Fetches the authenticated user
      */
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func me(_ session: RequestKitURLSession = URLSession.shared) async throws -> User {
+    func me() async throws -> User {
         let router = UserRouter.readAuthenticatedUser(configuration)
         return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: User.self)
     }

--- a/OctoKitCLI/Package.resolved
+++ b/OctoKitCLI/Package.resolved
@@ -26,6 +26,15 @@
         "revision" : "fddd1c00396eed152c45a46bea9f47b98e59301d",
         "version" : "1.2.0"
       }
+    },
+    {
+      "identity" : "swiftformat",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/nicklockwood/SwiftFormat",
+      "state" : {
+        "revision" : "a8b32a96ec569d5ceec207f19ff411aea5c878f7",
+        "version" : "0.51.12"
+      }
     }
   ],
   "version" : 2

--- a/OctoKitCLI/Sources/OctoKitCLI/Modules/Follower.swift
+++ b/OctoKitCLI/Sources/OctoKitCLI/Modules/Follower.swift
@@ -35,9 +35,9 @@ extension Follower {
         init() {}
 
         mutating func run() async throws {
-            let octokit = Octokit()
             let session = JSONInterceptingURLSession()
-            _ = try await octokit.followers(session, name: name)
+            let octokit = Octokit(session: session)
+            _ = try await octokit.followers(name: name)
             session.verbosePrint(verbose: verbose)
             try session.printResponseToFileOrConsole(filePath: filePath)
         }

--- a/OctoKitCLI/Sources/OctoKitCLI/Modules/Gist.swift
+++ b/OctoKitCLI/Sources/OctoKitCLI/Modules/Gist.swift
@@ -36,9 +36,9 @@ extension Gist {
         init() {}
 
         mutating func run() async throws {
-            let octokit = Octokit()
             let session = JSONInterceptingURLSession()
-            _ = try await octokit.gist(session, id: id)
+            let octokit = Octokit(session: session)
+            _ = try await octokit.gist(id: id)
             session.verbosePrint(verbose: verbose)
             try session.printResponseToFileOrConsole(filePath: filePath)
         }
@@ -60,9 +60,9 @@ extension Gist {
         init() {}
 
         mutating func run() async throws {
-            let octokit = Octokit()
             let session = JSONInterceptingURLSession()
-            _ = try await octokit.gists(session, owner: owner)
+            let octokit = Octokit(session: session)
+            _ = try await octokit.gists(owner: owner)
             session.verbosePrint(verbose: verbose)
             try session.printResponseToFileOrConsole(filePath: filePath)
         }

--- a/OctoKitCLI/Sources/OctoKitCLI/Modules/Issue.swift
+++ b/OctoKitCLI/Sources/OctoKitCLI/Modules/Issue.swift
@@ -42,9 +42,9 @@ extension Issue {
         init() {}
 
         mutating func run() async throws {
-            let octokit = Octokit()
             let session = JSONInterceptingURLSession()
-            _ = try await octokit.issue(session, owner: owner, repository: repository, number: number)
+            let octokit = Octokit(session: session)
+            _ = try await octokit.issue(owner: owner, repository: repository, number: number)
             session.verbosePrint(verbose: verbose)
             try session.printResponseToFileOrConsole(filePath: filePath)
         }
@@ -66,9 +66,9 @@ extension Issue {
         init() {}
 
         mutating func run() async throws {
-            let octokit = Octokit()
             let session = JSONInterceptingURLSession()
-            _ = try await octokit.issues(session, owner: owner, repository: repository)
+            let octokit = Octokit(session: session)
+            _ = try await octokit.issues(owner: owner, repository: repository)
             session.verbosePrint(verbose: verbose)
             try session.printResponseToFileOrConsole(filePath: filePath)
         }

--- a/OctoKitCLI/Sources/OctoKitCLI/Modules/Label.swift
+++ b/OctoKitCLI/Sources/OctoKitCLI/Modules/Label.swift
@@ -42,9 +42,9 @@ extension Label {
         init() {}
 
         mutating func run() async throws {
-            let octokit = Octokit()
             let session = JSONInterceptingURLSession()
-            _ = try await octokit.label(session, owner: owner, repository: repository, name: name)
+            let octokit = Octokit(session: session)
+            _ = try await octokit.label(owner: owner, repository: repository, name: name)
             session.verbosePrint(verbose: verbose)
             try session.printResponseToFileOrConsole(filePath: filePath)
         }
@@ -66,9 +66,9 @@ extension Label {
         init() {}
 
         mutating func run() async throws {
-            let octokit = Octokit()
             let session = JSONInterceptingURLSession()
-            _ = try await octokit.labels(session, owner: owner, repository: repository)
+            let octokit = Octokit(session: session)
+            _ = try await octokit.labels(owner: owner, repository: repository)
             session.verbosePrint(verbose: verbose)
             try session.printResponseToFileOrConsole(filePath: filePath)
         }

--- a/OctoKitCLI/Sources/OctoKitCLI/Modules/PullRequest.swift
+++ b/OctoKitCLI/Sources/OctoKitCLI/Modules/PullRequest.swift
@@ -42,9 +42,9 @@ extension PullRequest {
         init() {}
 
         mutating func run() async throws {
-            let octokit = Octokit()
             let session = JSONInterceptingURLSession()
-            _ = try await octokit.pullRequest(session, owner: owner, repository: repository, number: number)
+            let octokit = Octokit(session: session)
+            _ = try await octokit.pullRequest(owner: owner, repository: repository, number: number)
             session.verbosePrint(verbose: verbose)
             try session.printResponseToFileOrConsole(filePath: filePath)
         }
@@ -66,9 +66,9 @@ extension PullRequest {
         init() {}
 
         mutating func run() async throws {
-            let octokit = Octokit()
             let session = JSONInterceptingURLSession()
-            _ = try await octokit.pullRequests(session, owner: owner, repository: repository)
+            let octokit = Octokit(session: session)
+            _ = try await octokit.pullRequests(owner: owner, repository: repository)
             session.verbosePrint(verbose: verbose)
             try session.printResponseToFileOrConsole(filePath: filePath)
         }

--- a/OctoKitCLI/Sources/OctoKitCLI/Modules/Release.swift
+++ b/OctoKitCLI/Sources/OctoKitCLI/Modules/Release.swift
@@ -66,9 +66,9 @@ extension Release {
         init() {}
 
         mutating func run() async throws {
-            let octokit = Octokit()
             let session = JSONInterceptingURLSession()
-            _ = try await octokit.listReleases(session, owner: owner, repository: repository)
+            let octokit = Octokit(session: session)
+            _ = try await octokit.listReleases(owner: owner, repository: repository)
             session.verbosePrint(verbose: verbose)
             try session.printResponseToFileOrConsole(filePath: filePath)
         }

--- a/OctoKitCLI/Sources/OctoKitCLI/Modules/Repository.swift
+++ b/OctoKitCLI/Sources/OctoKitCLI/Modules/Repository.swift
@@ -39,9 +39,9 @@ extension Repository {
         init() {}
 
         mutating func run() async throws {
-            let octokit = Octokit()
             let session = JSONInterceptingURLSession()
-            _ = try await octokit.repository(session, owner: owner, name: name)
+            let octokit = Octokit(session: session)
+            _ = try await octokit.repository(owner: owner, name: name)
             session.verbosePrint(verbose: verbose)
             try session.printResponseToFileOrConsole(filePath: filePath)
         }
@@ -60,9 +60,9 @@ extension Repository {
         init() {}
 
         mutating func run() async throws {
-            let octokit = Octokit()
             let session = JSONInterceptingURLSession()
-            _ = try await octokit.repositories(session, owner: owner)
+            let octokit = Octokit(session: session)
+            _ = try await octokit.repositories(owner: owner)
             session.verbosePrint(verbose: verbose)
             try session.printResponseToFileOrConsole(filePath: filePath)
         }

--- a/OctoKitCLI/Sources/OctoKitCLI/Modules/Review.swift
+++ b/OctoKitCLI/Sources/OctoKitCLI/Modules/Review.swift
@@ -41,9 +41,9 @@ extension Review {
         init() {}
 
         mutating func run() async throws {
-            let octokit = Octokit()
             let session = JSONInterceptingURLSession()
-            _ = try await octokit.reviews(session, owner: owner, repository: repository, pullRequestNumber: number)
+            let octokit = Octokit(session: session)
+            _ = try await octokit.reviews(owner: owner, repository: repository, pullRequestNumber: number)
             session.verbosePrint(verbose: verbose)
             try session.printResponseToFileOrConsole(filePath: filePath)
         }

--- a/OctoKitCLI/Sources/OctoKitCLI/Modules/Star.swift
+++ b/OctoKitCLI/Sources/OctoKitCLI/Modules/Star.swift
@@ -35,9 +35,9 @@ extension Star {
         init() {}
 
         mutating func run() async throws {
-            let octokit = Octokit()
             let session = JSONInterceptingURLSession()
-            _ = try await octokit.stars(session, name: name)
+            let octokit = Octokit(session: session)
+            _ = try await octokit.stars(name: name)
             session.verbosePrint(verbose: verbose)
             try session.printResponseToFileOrConsole(filePath: filePath)
         }

--- a/OctoKitCLI/Sources/OctoKitCLI/Modules/Status.swift
+++ b/OctoKitCLI/Sources/OctoKitCLI/Modules/Status.swift
@@ -41,9 +41,9 @@ extension Status {
         init() {}
 
         mutating func run() async throws {
-            let octokit = Octokit()
             let session = JSONInterceptingURLSession()
-            _ = try await octokit.listCommitStatuses(session, owner: owner, repository: repository, ref: reference)
+            let octokit = Octokit(session: session)
+            _ = try await octokit.listCommitStatuses(owner: owner, repository: repository, ref: reference)
             session.verbosePrint(verbose: verbose)
             try session.printResponseToFileOrConsole(filePath: filePath)
         }

--- a/OctoKitCLI/Sources/OctoKitCLI/Modules/User.swift
+++ b/OctoKitCLI/Sources/OctoKitCLI/Modules/User.swift
@@ -35,9 +35,9 @@ extension User {
         init() {}
 
         mutating func run() async throws {
-            let octokit = Octokit()
             let session = JSONInterceptingURLSession()
-            _ = try await octokit.user(session, name: name)
+            let octokit = Octokit(session: session)
+            _ = try await octokit.user(name: name)
             session.verbosePrint(verbose: verbose)
             try session.printResponseToFileOrConsole(filePath: filePath)
         }

--- a/Tests/OctoKitTests/ConfigurationTests.swift
+++ b/Tests/OctoKitTests/ConfigurationTests.swift
@@ -46,12 +46,12 @@ class ConfigurationTests: XCTestCase {
     }
 
     func testHandleOpenURL() {
-        let config = OAuthConfiguration(token: "12345", secret: "6789", scopes: ["repo", "read:org"])
         let response = "access_token=017ec60f4a182&scope=read%3Aorg%2Crepo&token_type=bearer"
         let session = OctoKitURLTestSession(expectedURL: "https://github.com/login/oauth/access_token", expectedHTTPMethod: "POST", response: response, statusCode: 200)
+        let config = OAuthConfiguration(token: "12345", secret: "6789", scopes: ["repo", "read:org"], session: session)
         let url = URL(string: "urlscheme://authorize?code=dhfjgh23493&state=")!
         var token: String?
-        config.handleOpenURL(session, url: url) { accessToken in
+        config.handleOpenURL(url: url) { accessToken in
             token = accessToken.accessToken
         }
         XCTAssertEqual(token, "017ec60f4a182".data(using: .utf8)?.base64EncodedString())

--- a/Tests/OctoKitTests/FollowTests.swift
+++ b/Tests/OctoKitTests/FollowTests.swift
@@ -7,7 +7,7 @@ class FollowTests: XCTestCase {
         let headers = Helper.makeAuthHeader(username: "user", password: "12345")
 
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/user/followers", expectedHTTPMethod: "GET", expectedHTTPHeaders: headers, jsonFile: "users", statusCode: 200)
-        let task = Octokit(config).myFollowers(session) { response in
+        let task = Octokit(config, session: session).myFollowers { response in
             switch response {
             case let .success(users):
                 XCTAssertEqual(users.count, 1)
@@ -26,7 +26,7 @@ class FollowTests: XCTestCase {
         let headers = Helper.makeAuthHeader(username: "user", password: "12345")
 
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/user/followers", expectedHTTPMethod: "GET", expectedHTTPHeaders: headers, jsonFile: "users", statusCode: 200)
-        let users = try await Octokit(config).myFollowers(session)
+        let users = try await Octokit(config, session: session).myFollowers()
         XCTAssertEqual(users.count, 1)
         XCTAssertTrue(session.wasCalled)
     }
@@ -34,7 +34,7 @@ class FollowTests: XCTestCase {
 
     func testGetUsersFollowers() {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/users/octocat/followers", expectedHTTPMethod: "GET", jsonFile: "users", statusCode: 200)
-        let task = Octokit().followers(session, name: "octocat") { response in
+        let task = Octokit(session: session).followers(name: "octocat") { response in
             switch response {
             case let .success(users):
                 XCTAssertEqual(users.count, 1)
@@ -50,7 +50,7 @@ class FollowTests: XCTestCase {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func testGetUsersFollowersAsync() async throws {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/users/octocat/followers", expectedHTTPMethod: "GET", jsonFile: "users", statusCode: 200)
-        let users = try await Octokit().followers(session, name: "octocat")
+        let users = try await Octokit(session: session).followers(name: "octocat")
         XCTAssertEqual(users.count, 1)
         XCTAssertTrue(session.wasCalled)
     }
@@ -61,7 +61,7 @@ class FollowTests: XCTestCase {
         let headers = Helper.makeAuthHeader(username: "user", password: "12345")
 
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/user/following", expectedHTTPMethod: "GET", expectedHTTPHeaders: headers, jsonFile: "users", statusCode: 200)
-        let task = Octokit(config).myFollowing(session) { response in
+        let task = Octokit(config, session: session).myFollowing { response in
             switch response {
             case let .success(users):
                 XCTAssertEqual(users.count, 1)
@@ -80,7 +80,7 @@ class FollowTests: XCTestCase {
         let headers = Helper.makeAuthHeader(username: "user", password: "12345")
 
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/user/following", expectedHTTPMethod: "GET", expectedHTTPHeaders: headers, jsonFile: "users", statusCode: 200)
-        let users = try await Octokit(config).myFollowing(session)
+        let users = try await Octokit(config, session: session).myFollowing()
         XCTAssertEqual(users.count, 1)
         XCTAssertTrue(session.wasCalled)
     }
@@ -88,7 +88,7 @@ class FollowTests: XCTestCase {
 
     func testGetUsersFollowing() {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/users/octocat/following", expectedHTTPMethod: "GET", jsonFile: "users", statusCode: 200)
-        let task = Octokit().following(session, name: "octocat") { response in
+        let task = Octokit(session: session).following(name: "octocat") { response in
             switch response {
             case let .success(users):
                 XCTAssertEqual(users.count, 1)
@@ -104,7 +104,7 @@ class FollowTests: XCTestCase {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func testGetUsersFollowingAsync() async throws {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/users/octocat/following", expectedHTTPMethod: "GET", jsonFile: "users", statusCode: 200)
-        let users = try await Octokit().following(session, name: "octocat")
+        let users = try await Octokit(session: session).following(name: "octocat")
         XCTAssertEqual(users.count, 1)
         XCTAssertTrue(session.wasCalled)
     }

--- a/Tests/OctoKitTests/GistTests.swift
+++ b/Tests/OctoKitTests/GistTests.swift
@@ -15,7 +15,7 @@ class GistTests: XCTestCase {
                                             expectedHTTPHeaders: headers,
                                             jsonFile: "gists",
                                             statusCode: 200)
-        let task = Octokit(config).myGists(session) { response in
+        let task = Octokit(config, session: session).myGists { response in
             switch response {
             case let .success(gists):
                 XCTAssertEqual(gists.count, 1)
@@ -38,7 +38,7 @@ class GistTests: XCTestCase {
                                             expectedHTTPHeaders: headers,
                                             jsonFile: "gists",
                                             statusCode: 200)
-        let gists = try await Octokit(config).myGists(session)
+        let gists = try await Octokit(config, session: session).myGists()
         XCTAssertEqual(gists.count, 1)
         XCTAssertTrue(session.wasCalled)
     }
@@ -53,7 +53,7 @@ class GistTests: XCTestCase {
                                             expectedHTTPHeaders: headers,
                                             jsonFile: "gists",
                                             statusCode: 200)
-        let task = Octokit(config).gists(session, owner: "vincode-io") { response in
+        let task = Octokit(config, session: session).gists(owner: "vincode-io") { response in
             switch response {
             case let .success(gists):
                 XCTAssertEqual(gists.count, 1)
@@ -76,7 +76,7 @@ class GistTests: XCTestCase {
                                             expectedHTTPHeaders: headers,
                                             jsonFile: "gists",
                                             statusCode: 200)
-        let gists = try await Octokit(config).gists(session, owner: "vincode-io")
+        let gists = try await Octokit(config, session: session).gists(owner: "vincode-io")
         XCTAssertEqual(gists.count, 1)
         XCTAssertTrue(session.wasCalled)
     }
@@ -84,7 +84,7 @@ class GistTests: XCTestCase {
 
     func testGetGist() {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/gists/aa5a315d61ae9438b18d", expectedHTTPMethod: "GET", jsonFile: "gist", statusCode: 200)
-        let task = Octokit().gist(session, id: "aa5a315d61ae9438b18d") { response in
+        let task = Octokit(session: session).gist(id: "aa5a315d61ae9438b18d") { response in
             switch response {
             case let .success(gist):
                 XCTAssertEqual(gist.id, "aa5a315d61ae9438b18d")
@@ -100,7 +100,7 @@ class GistTests: XCTestCase {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func testGetGistAsync() async throws {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/gists/aa5a315d61ae9438b18d", expectedHTTPMethod: "GET", jsonFile: "gist", statusCode: 200)
-        let gist = try await Octokit().gist(session, id: "aa5a315d61ae9438b18d")
+        let gist = try await Octokit(session: session).gist(id: "aa5a315d61ae9438b18d")
         XCTAssertEqual(gist.id, "aa5a315d61ae9438b18d")
         XCTAssertTrue(session.wasCalled)
     }
@@ -108,7 +108,7 @@ class GistTests: XCTestCase {
 
     func testPostGist() {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/gists", expectedHTTPMethod: "POST", jsonFile: "gist", statusCode: 200)
-        let task = Octokit().postGistFile(session, description: "Test Post", filename: "Hello-World.swift", fileContent: "Sample Program", publicAccess: true) { response in
+        let task = Octokit(session: session).postGistFile(description: "Test Post", filename: "Hello-World.swift", fileContent: "Sample Program", publicAccess: true) { response in
             switch response {
             case let .success(gist):
                 XCTAssertEqual(gist.id, "aa5a315d61ae9438b18d")
@@ -125,7 +125,7 @@ class GistTests: XCTestCase {
     func testPostGistAsync() async throws {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/gists", expectedHTTPMethod: "POST", jsonFile: "gist", statusCode: 200)
         do {
-            let gist = try await Octokit().postGistFile(session, description: "Test Post", filename: "Hello-World.swift", fileContent: "Sample Program", publicAccess: true)
+            let gist = try await Octokit(session: session).postGistFile(description: "Test Post", filename: "Hello-World.swift", fileContent: "Sample Program", publicAccess: true)
             XCTAssertEqual(gist.id, "aa5a315d61ae9438b18d")
             XCTAssertTrue(session.wasCalled)
         } catch {
@@ -136,7 +136,7 @@ class GistTests: XCTestCase {
 
     func testPatchGist() {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/gists/aa5a315d61ae9438b18d", expectedHTTPMethod: "POST", jsonFile: "gist", statusCode: 200)
-        let task = Octokit().patchGistFile(session, id: "aa5a315d61ae9438b18d", description: "Test Post", filename: "Hello-World.swift", fileContent: "Sample Program") { response in
+        let task = Octokit(session: session).patchGistFile(id: "aa5a315d61ae9438b18d", description: "Test Post", filename: "Hello-World.swift", fileContent: "Sample Program") { response in
             switch response {
             case let .success(gist):
                 XCTAssertEqual(gist.id, "aa5a315d61ae9438b18d")
@@ -152,7 +152,7 @@ class GistTests: XCTestCase {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func testPatchGistAsync() async throws {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/gists/aa5a315d61ae9438b18d", expectedHTTPMethod: "POST", jsonFile: "gist", statusCode: 200)
-        let gist = try await Octokit().patchGistFile(session, id: "aa5a315d61ae9438b18d", description: "Test Post", filename: "Hello-World.swift", fileContent: "Sample Program")
+        let gist = try await Octokit(session: session).patchGistFile(id: "aa5a315d61ae9438b18d", description: "Test Post", filename: "Hello-World.swift", fileContent: "Sample Program")
         XCTAssertEqual(gist.id, "aa5a315d61ae9438b18d")
         XCTAssertTrue(session.wasCalled)
     }

--- a/Tests/OctoKitTests/IssueTests.swift
+++ b/Tests/OctoKitTests/IssueTests.swift
@@ -13,7 +13,7 @@ class IssueTests: XCTestCase {
                                             expectedHTTPHeaders: headers,
                                             jsonFile: "issues",
                                             statusCode: 200)
-        let task = Octokit(config).myIssues(session) { response in
+        let task = Octokit(config, session: session).myIssues { response in
             switch response {
             case let .success(issues):
                 XCTAssertEqual(issues.count, 1)
@@ -36,7 +36,7 @@ class IssueTests: XCTestCase {
                                             expectedHTTPHeaders: headers,
                                             jsonFile: "issues",
                                             statusCode: 200)
-        let issues = try await Octokit(config).myIssues(session)
+        let issues = try await Octokit(config, session: session).myIssues()
         XCTAssertEqual(issues.count, 1)
         XCTAssertTrue(session.wasCalled)
     }
@@ -44,7 +44,7 @@ class IssueTests: XCTestCase {
 
     func testGetIssue() {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/Hello-World/issues/1347", expectedHTTPMethod: "GET", jsonFile: "issue", statusCode: 200)
-        let task = Octokit().issue(session, owner: "octocat", repository: "Hello-World", number: 1347) { response in
+        let task = Octokit(session: session).issue(owner: "octocat", repository: "Hello-World", number: 1347) { response in
             switch response {
             case let .success(issue):
                 XCTAssertEqual(issue.number, 1347)
@@ -60,7 +60,7 @@ class IssueTests: XCTestCase {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func testGetIssueAsync() async throws {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/Hello-World/issues/1347", expectedHTTPMethod: "GET", jsonFile: "issue", statusCode: 200)
-        let issue = try await Octokit().issue(session, owner: "octocat", repository: "Hello-World", number: 1347)
+        let issue = try await Octokit(session: session).issue(owner: "octocat", repository: "Hello-World", number: 1347)
         XCTAssertEqual(issue.number, 1347)
         XCTAssertTrue(session.wasCalled)
     }
@@ -68,7 +68,7 @@ class IssueTests: XCTestCase {
 
     func testPostIssue() {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/Hello-World/issues", expectedHTTPMethod: "POST", jsonFile: "issue2", statusCode: 200)
-        let task = Octokit().postIssue(session, owner: "octocat", repository: "Hello-World", title: "Title", body: "Body") { response in
+        let task = Octokit(session: session).postIssue(owner: "octocat", repository: "Hello-World", title: "Title", body: "Body") { response in
             switch response {
             case let .success(issue):
                 XCTAssertEqual(issue.number, 36)
@@ -84,7 +84,7 @@ class IssueTests: XCTestCase {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func testPostIssueAsync() async throws {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/Hello-World/issues", expectedHTTPMethod: "POST", jsonFile: "issue2", statusCode: 200)
-        let issue = try await Octokit().postIssue(session, owner: "octocat", repository: "Hello-World", title: "Title", body: "Body")
+        let issue = try await Octokit(session: session).postIssue(owner: "octocat", repository: "Hello-World", title: "Title", body: "Body")
         XCTAssertEqual(issue.number, 36)
         XCTAssertTrue(session.wasCalled)
     }
@@ -92,7 +92,7 @@ class IssueTests: XCTestCase {
 
     func testPostComment() {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/Hello-World/issues/1/comments", expectedHTTPMethod: "POST", jsonFile: "issue_comment", statusCode: 201)
-        let task = Octokit().commentIssue(session, owner: "octocat", repository: "Hello-World", number: 1, body: "Testing a comment") { response in
+        let task = Octokit(session: session).commentIssue(owner: "octocat", repository: "Hello-World", number: 1, body: "Testing a comment") { response in
             switch response {
             case let .success(comment):
                 XCTAssertEqual(comment.body, "Testing a comment")
@@ -111,7 +111,7 @@ class IssueTests: XCTestCase {
                                             expectedHTTPMethod: "POST",
                                             jsonFile: "issue_comment",
                                             statusCode: 201)
-        let comment = try await Octokit().commentIssue(session, owner: "octocat", repository: "Hello-World", number: 1, body: "Testing a comment")
+        let comment = try await Octokit(session: session).commentIssue(owner: "octocat", repository: "Hello-World", number: 1, body: "Testing a comment")
         XCTAssertEqual(comment.body, "Testing a comment")
         XCTAssertTrue(session.wasCalled)
     }
@@ -122,7 +122,7 @@ class IssueTests: XCTestCase {
                                             expectedHTTPMethod: "GET",
                                             jsonFile: "issue_comments",
                                             statusCode: 200)
-        let task = Octokit().issueComments(session, owner: "octocat", repository: "Hello-World", number: 1) { response in
+        let task = Octokit(session: session).issueComments(owner: "octocat", repository: "Hello-World", number: 1) { response in
             switch response {
             case let .success(comments):
                 XCTAssertEqual(comments.count, 1)
@@ -143,7 +143,7 @@ class IssueTests: XCTestCase {
                                             expectedHTTPMethod: "GET",
                                             jsonFile: "issue_comments",
                                             statusCode: 200)
-        let comments = try await Octokit().issueComments(session, owner: "octocat", repository: "Hello-World", number: 1)
+        let comments = try await Octokit(session: session).issueComments(owner: "octocat", repository: "Hello-World", number: 1)
         XCTAssertEqual(comments.count, 1)
         XCTAssertEqual(comments[0].body, "Testing fetching comments for an issue")
         XCTAssertEqual(comments[0].reactions!.totalCount, 5)
@@ -153,7 +153,7 @@ class IssueTests: XCTestCase {
 
     func testPatchComment() {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/Hello-World/issues/comments/1", expectedHTTPMethod: "POST", jsonFile: "issue_comment", statusCode: 201)
-        let task = Octokit().patchIssueComment(session, owner: "octocat", repository: "Hello-World", number: 1, body: "Testing a comment") { response in
+        let task = Octokit(session: session).patchIssueComment(owner: "octocat", repository: "Hello-World", number: 1, body: "Testing a comment") { response in
             switch response {
             case let .success(comment):
                 XCTAssertEqual(comment.body, "Testing a comment")

--- a/Tests/OctoKitTests/LabelTests.swift
+++ b/Tests/OctoKitTests/LabelTests.swift
@@ -6,7 +6,7 @@ class LabelTests: XCTestCase {
 
     func testGetLabel() {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/hello-world/labels/bug", expectedHTTPMethod: "GET", jsonFile: "label", statusCode: 200)
-        let task = Octokit().label(session, owner: "octocat", repository: "hello-world", name: "bug") { response in
+        let task = Octokit(session: session).label(owner: "octocat", repository: "hello-world", name: "bug") { response in
             switch response {
             case let .success(label):
                 XCTAssertEqual(label.name, "bug")
@@ -22,7 +22,7 @@ class LabelTests: XCTestCase {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func testGetLabelAsync() async throws {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/hello-world/labels/bug", expectedHTTPMethod: "GET", jsonFile: "label", statusCode: 200)
-        let label = try await Octokit().label(session, owner: "octocat", repository: "hello-world", name: "bug")
+        let label = try await Octokit(session: session).label(owner: "octocat", repository: "hello-world", name: "bug")
         XCTAssertEqual(label.name, "bug")
         XCTAssertTrue(session.wasCalled)
     }
@@ -30,7 +30,7 @@ class LabelTests: XCTestCase {
 
     func testGetLabelEncodesSpaceCorrectly() {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/hello-world/labels/help%20wanted", expectedHTTPMethod: "GET", jsonFile: nil, statusCode: 200)
-        let task = Octokit().label(session, owner: "octocat", repository: "hello-world", name: "help wanted") { response in
+        let task = Octokit(session: session).label(owner: "octocat", repository: "hello-world", name: "help wanted") { response in
             switch response {
             case .success:
                 XCTAssert(true)
@@ -44,7 +44,7 @@ class LabelTests: XCTestCase {
 
     func testGetLabels() {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/hello-world/labels?page=1&per_page=100", expectedHTTPMethod: "GET", jsonFile: "labels", statusCode: 200)
-        let task = Octokit().labels(session, owner: "octocat", repository: "hello-world") { response in
+        let task = Octokit(session: session).labels(owner: "octocat", repository: "hello-world") { response in
             switch response {
             case let .success(labels):
                 XCTAssertEqual(labels.count, 7)
@@ -63,7 +63,7 @@ class LabelTests: XCTestCase {
                                             expectedHTTPMethod: "GET",
                                             jsonFile: "labels",
                                             statusCode: 200)
-        let labels = try await Octokit().labels(session, owner: "octocat", repository: "hello-world")
+        let labels = try await Octokit(session: session).labels(owner: "octocat", repository: "hello-world")
         XCTAssertEqual(labels.count, 7)
         XCTAssertTrue(session.wasCalled)
     }
@@ -71,7 +71,7 @@ class LabelTests: XCTestCase {
 
     func testGetLabelsSetsPagination() {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/hello-world/labels?page=2&per_page=50", expectedHTTPMethod: "GET", jsonFile: nil, statusCode: 200)
-        let task = Octokit().labels(session, owner: "octocat", repository: "hello-world", page: "2", perPage: "50") { response in
+        let task = Octokit(session: session).labels(owner: "octocat", repository: "hello-world", page: "2", perPage: "50") { response in
             switch response {
             case .success:
                 XCTAssert(true)
@@ -85,7 +85,7 @@ class LabelTests: XCTestCase {
 
     func testCreateLabel() {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/hello-world/labels", expectedHTTPMethod: "POST", jsonFile: "label", statusCode: 200)
-        let task = Octokit().postLabel(session, owner: "octocat", repository: "hello-world", name: "test label", color: "ffffff") { response in
+        let task = Octokit(session: session).postLabel(owner: "octocat", repository: "hello-world", name: "test label", color: "ffffff") { response in
             switch response {
             case let .success(label):
                 XCTAssertNotNil(label)
@@ -101,7 +101,7 @@ class LabelTests: XCTestCase {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func testCreateLabelAsync() async throws {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/hello-world/labels", expectedHTTPMethod: "POST", jsonFile: "label", statusCode: 200)
-        let label = try await Octokit().postLabel(session, owner: "octocat", repository: "hello-world", name: "test label", color: "ffffff")
+        let label = try await Octokit(session: session).postLabel(owner: "octocat", repository: "hello-world", name: "test label", color: "ffffff")
         XCTAssertNotNil(label)
         XCTAssertTrue(session.wasCalled)
     }

--- a/Tests/OctoKitTests/NotificationTests.swift
+++ b/Tests/OctoKitTests/NotificationTests.swift
@@ -13,7 +13,7 @@ class NotificationTests: XCTestCase {
                                             expectedHTTPHeaders: headers,
                                             jsonFile: "notification_threads",
                                             statusCode: 200)
-        let task = Octokit(config).myNotifications(session, all: false, participating: false, page: "1", perPage: "100") { response in
+        let task = Octokit(config, session: session).myNotifications(all: false, participating: false, page: "1", perPage: "100") { response in
             switch response {
             case let .success(notifications):
                 XCTAssertEqual(notifications.count, 1)
@@ -34,7 +34,7 @@ class NotificationTests: XCTestCase {
                                             expectedHTTPHeaders: headers,
                                             response: "",
                                             statusCode: 200)
-        let task = Octokit(config).markNotificationsRead(session) { response in
+        let task = Octokit(config, session: session).markNotificationsRead { response in
             XCTAssertNil(response)
         }
         XCTAssertNotNil(task)
@@ -49,7 +49,7 @@ class NotificationTests: XCTestCase {
                                             expectedHTTPHeaders: headers,
                                             jsonFile: "notification_thread",
                                             statusCode: 200)
-        let task = Octokit(config).getNotificationThread(session, threadId: "1") { response in
+        let task = Octokit(config, session: session).getNotificationThread(threadId: "1") { response in
             switch response {
             case let .success(notification):
                 XCTAssertEqual(notification.id, "1")
@@ -69,7 +69,7 @@ class NotificationTests: XCTestCase {
                                             expectedHTTPHeaders: headers,
                                             jsonFile: "notification_thread_subscription",
                                             statusCode: 200)
-        let task = Octokit(config).getThreadSubscription(session, threadId: "1") { response in
+        let task = Octokit(config, session: session).getThreadSubscription(threadId: "1") { response in
             switch response {
             case let .success(notification):
                 XCTAssertEqual(notification.id, 1)
@@ -89,7 +89,7 @@ class NotificationTests: XCTestCase {
                                             expectedHTTPHeaders: headers,
                                             jsonFile: "notification_thread_subscription",
                                             statusCode: 200)
-        let task = Octokit(config).setThreadSubscription(session, threadId: "1") { response in
+        let task = Octokit(config, session: session).setThreadSubscription(threadId: "1") { response in
             switch response {
             case let .success(notification):
                 XCTAssertEqual(notification.id, 1)
@@ -109,7 +109,7 @@ class NotificationTests: XCTestCase {
                                             expectedHTTPHeaders: headers,
                                             response: "",
                                             statusCode: 200)
-        let task = Octokit(config).deleteThreadSubscription(session, threadId: "1") { response in
+        let task = Octokit(config, session: session).deleteThreadSubscription(threadId: "1") { response in
             XCTAssertNil(response)
         }
         XCTAssertNotNil(task)
@@ -124,7 +124,7 @@ class NotificationTests: XCTestCase {
                                             expectedHTTPHeaders: headers,
                                             jsonFile: "notification_threads",
                                             statusCode: 200)
-        let task = Octokit(config).listRepositoryNotifications(session, owner: "octocat", repository: "hello-world") { response in
+        let task = Octokit(config, session: session).listRepositoryNotifications(owner: "octocat", repository: "hello-world") { response in
             switch response {
             case let .success(notifications):
                 XCTAssertEqual(notifications.count, 1)
@@ -145,7 +145,7 @@ class NotificationTests: XCTestCase {
                                             expectedHTTPHeaders: headers,
                                             response: "",
                                             statusCode: 200)
-        let task = Octokit(config).markRepositoryNotificationsRead(session, owner: "octocat", repository: "hello-world") { response in
+        let task = Octokit(config, session: session).markRepositoryNotificationsRead(owner: "octocat", repository: "hello-world") { response in
             XCTAssertNil(response)
         }
         XCTAssertNotNil(task)

--- a/Tests/OctoKitTests/PublicKeyTests.swift
+++ b/Tests/OctoKitTests/PublicKeyTests.swift
@@ -10,7 +10,7 @@ class PublicKeyTests: XCTestCase {
         let headers = Helper.makeAuthHeader(username: "user", password: "12345")
 
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/user/keys", expectedHTTPMethod: "POST", expectedHTTPHeaders: headers, jsonFile: "public_key", statusCode: 201)
-        let task = Octokit(config).postPublicKey(session, publicKey: "test-key", title: "test title") { response in
+        let task = Octokit(config, session: session).postPublicKey(publicKey: "test-key", title: "test title") { response in
             switch response {
             case let .success(publicKey):
                 XCTAssertEqual(publicKey, "test-key")
@@ -29,7 +29,7 @@ class PublicKeyTests: XCTestCase {
         let headers = Helper.makeAuthHeader(username: "user", password: "12345")
 
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/user/keys", expectedHTTPMethod: "POST", expectedHTTPHeaders: headers, jsonFile: "public_key", statusCode: 201)
-        let publicKey = try await Octokit(config).postPublicKey(session, publicKey: "test-key", title: "test title")
+        let publicKey = try await Octokit(config, session: session).postPublicKey(publicKey: "test-key", title: "test title")
         XCTAssertEqual(publicKey, "test-key")
         XCTAssertTrue(session.wasCalled)
     }

--- a/Tests/OctoKitTests/PullRequestTests.swift
+++ b/Tests/OctoKitTests/PullRequestTests.swift
@@ -8,7 +8,7 @@ class PullRequestTests: XCTestCase {
                                             jsonFile: "pull_request",
                                             statusCode: 200)
 
-        let task = Octokit().pullRequest(session, owner: "octocat", repository: "Hello-World", number: 1) { response in
+        let task = Octokit(session: session).pullRequest(owner: "octocat", repository: "Hello-World", number: 1) { response in
             switch response {
             case let .success(pullRequests):
                 XCTAssertEqual(pullRequests.id, 1)
@@ -46,7 +46,7 @@ class PullRequestTests: XCTestCase {
                                             jsonFile: "pull_request",
                                             statusCode: 200)
 
-        let pullRequest = try await Octokit().pullRequest(session, owner: "octocat", repository: "Hello-World", number: 1)
+        let pullRequest = try await Octokit(session: session).pullRequest(owner: "octocat", repository: "Hello-World", number: 1)
         XCTAssertEqual(pullRequest.id, 1)
         XCTAssertEqual(pullRequest.title, "new-feature")
         XCTAssertEqual(pullRequest.body, "Please pull these awesome changes")
@@ -73,12 +73,12 @@ class PullRequestTests: XCTestCase {
     func testGetPullRequests() {
         // Test filtering with on the base branch
 
-        let baseSession = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/Hello-World/pulls?base=develop&direction=desc&sort=created&state=open",
-                                                expectedHTTPMethod: "GET",
-                                                jsonFile: "pull_requests",
-                                                statusCode: 200)
+        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/Hello-World/pulls?base=develop&direction=desc&sort=created&state=open",
+                                            expectedHTTPMethod: "GET",
+                                            jsonFile: "pull_requests",
+                                            statusCode: 200)
 
-        let baseTask = Octokit().pullRequests(baseSession, owner: "octocat", repository: "Hello-World", base: "develop", state: Openness.open) { response in
+        let task = Octokit(session: session).pullRequests(owner: "octocat", repository: "Hello-World", base: "develop", state: Openness.open) { response in
             switch response {
             case let .success(pullRequests):
                 XCTAssertEqual(pullRequests.count, 1)
@@ -104,20 +104,20 @@ class PullRequestTests: XCTestCase {
                 XCTAssertNil(error)
             }
         }
-        XCTAssertNotNil(baseTask)
-        XCTAssertTrue(baseSession.wasCalled)
+        XCTAssertNotNil(task)
+        XCTAssertTrue(session.wasCalled)
     }
 
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func testGetPullRequestsAsync() async throws {
         // Test filtering with on the base branch
-        let baseSession = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/Hello-World/pulls?base=develop&direction=desc&sort=created&state=open",
-                                                expectedHTTPMethod: "GET",
-                                                jsonFile: "pull_requests",
-                                                statusCode: 200)
+        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/Hello-World/pulls?base=develop&direction=desc&sort=created&state=open",
+                                            expectedHTTPMethod: "GET",
+                                            jsonFile: "pull_requests",
+                                            statusCode: 200)
 
-        let pullRequests = try await Octokit().pullRequests(baseSession, owner: "octocat", repository: "Hello-World", base: "develop", state: Openness.open)
+        let pullRequests = try await Octokit(session: session).pullRequests(owner: "octocat", repository: "Hello-World", base: "develop", state: Openness.open)
         XCTAssertEqual(pullRequests.count, 1)
         XCTAssertEqual(pullRequests.first?.title, "new-feature")
         XCTAssertEqual(pullRequests.first?.body, "Please pull these awesome changes")
@@ -137,18 +137,18 @@ class PullRequestTests: XCTestCase {
         XCTAssertEqual(pullRequests.first?.head?.repo?.name, "Hello-World")
         XCTAssertEqual(pullRequests.first?.requestedReviewers?[0].login, "octocat")
         XCTAssertEqual(pullRequests.first?.draft, false)
-        XCTAssertTrue(baseSession.wasCalled)
+        XCTAssertTrue(session.wasCalled)
     }
     #endif
 
     func testGetPullRequestWithHead() {
         // Test filtering with on the head branch
-        let headSession = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/Hello-World/pulls?direction=desc&head=octocat%3Anew-topic&sort=created&state=open",
-                                                expectedHTTPMethod: "GET",
-                                                jsonFile: "pull_requests",
-                                                statusCode: 200)
+        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/Hello-World/pulls?direction=desc&head=octocat%3Anew-topic&sort=created&state=open",
+                                            expectedHTTPMethod: "GET",
+                                            jsonFile: "pull_requests",
+                                            statusCode: 200)
 
-        let headTask = Octokit().pullRequests(headSession, owner: "octocat", repository: "Hello-World", head: "octocat:new-topic", state: Openness.open) { response in
+        let task = Octokit(session: session).pullRequests(owner: "octocat", repository: "Hello-World", head: "octocat:new-topic", state: Openness.open) { response in
             switch response {
             case let .success(pullRequests):
                 XCTAssertEqual(pullRequests.count, 1)
@@ -174,20 +174,20 @@ class PullRequestTests: XCTestCase {
                 XCTAssertNil(error)
             }
         }
-        XCTAssertNotNil(headTask)
-        XCTAssertTrue(headSession.wasCalled)
+        XCTAssertNotNil(task)
+        XCTAssertTrue(session.wasCalled)
     }
 
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func testGetPullRequestsWithHeadAsync() async throws {
         // Test filtering with on the head branch
-        let headSession = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/Hello-World/pulls?direction=desc&head=octocat%3Anew-topic&sort=created&state=open",
-                                                expectedHTTPMethod: "GET",
-                                                jsonFile: "pull_requests",
-                                                statusCode: 200)
+        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/Hello-World/pulls?direction=desc&head=octocat%3Anew-topic&sort=created&state=open",
+                                            expectedHTTPMethod: "GET",
+                                            jsonFile: "pull_requests",
+                                            statusCode: 200)
 
-        let pullRequests = try await Octokit().pullRequests(headSession, owner: "octocat", repository: "Hello-World", head: "octocat:new-topic", state: Openness.open)
+        let pullRequests = try await Octokit(session: session).pullRequests(owner: "octocat", repository: "Hello-World", head: "octocat:new-topic", state: Openness.open)
         XCTAssertEqual(pullRequests.count, 1)
         XCTAssertEqual(pullRequests.first?.title, "new-feature")
         XCTAssertEqual(pullRequests.first?.body, "Please pull these awesome changes")
@@ -207,7 +207,7 @@ class PullRequestTests: XCTestCase {
         XCTAssertEqual(pullRequests.first?.head?.repo?.name, "Hello-World")
         XCTAssertEqual(pullRequests.first?.requestedReviewers?[0].login, "octocat")
         XCTAssertEqual(pullRequests.first?.draft, false)
-        XCTAssertTrue(headSession.wasCalled)
+        XCTAssertTrue(session.wasCalled)
     }
     #endif
 
@@ -217,8 +217,8 @@ class PullRequestTests: XCTestCase {
                                             jsonFile: "pull_request",
                                             statusCode: 200)
 
-        let task = Octokit()
-            .patchPullRequest(session, owner: "octocat", repository: "Hello-World", number: 1, title: "new-title", body: "new-body", state: .open, base: "base-branch",
+        let task = Octokit(session: session)
+            .patchPullRequest(owner: "octocat", repository: "Hello-World", number: 1, title: "new-title", body: "new-body", state: .open, base: "base-branch",
                               mantainerCanModify: true) { response in
                 switch response {
                 case let .success(pullrequest):
@@ -257,8 +257,8 @@ class PullRequestTests: XCTestCase {
                                             jsonFile: "pull_request",
                                             statusCode: 200)
 
-        let pullrequest = try await Octokit()
-            .patchPullRequest(session, owner: "octocat", repository: "Hello-World", number: 1, title: "new-title", body: "new-body", state: .open, base: "base-branch", mantainerCanModify: true)
+        let pullrequest = try await Octokit(session: session)
+            .patchPullRequest(owner: "octocat", repository: "Hello-World", number: 1, title: "new-title", body: "new-body", state: .open, base: "base-branch", mantainerCanModify: true)
 
         XCTAssertEqual(pullrequest.id, 1)
         XCTAssertEqual(pullrequest.title, "new-feature")
@@ -289,15 +289,14 @@ class PullRequestTests: XCTestCase {
                                             jsonFile: "created_pull_request",
                                             statusCode: 200)
 
-        let task = Octokit().createPullRequest(session,
-                                               owner: "octocat",
-                                               repo: "Hello-World",
-                                               title: "Amazing new feature",
-                                               head: "octocat:new-feature",
-                                               base: "master",
-                                               body: "Please pull these awesome changes in!",
-                                               maintainerCanModify: true,
-                                               draft: false) { response in
+        let task = Octokit(session: session).createPullRequest(owner: "octocat",
+                                                               repo: "Hello-World",
+                                                               title: "Amazing new feature",
+                                                               head: "octocat:new-feature",
+                                                               base: "master",
+                                                               body: "Please pull these awesome changes in!",
+                                                               maintainerCanModify: true,
+                                                               draft: false) { response in
             switch response {
             case let .success(pullRequest):
                 XCTAssertEqual(pullRequest.id, 1)
@@ -335,9 +334,8 @@ class PullRequestTests: XCTestCase {
                                             jsonFile: "created_pull_request",
                                             statusCode: 200)
 
-        let pullRequest = try await Octokit()
-            .createPullRequest(session,
-                               owner: "octocat",
+        let pullRequest = try await Octokit(session: session)
+            .createPullRequest(owner: "octocat",
                                repo: "Hello-World",
                                title: "Amazing new feature",
                                head: "octocat:new-feature",

--- a/Tests/OctoKitTests/ReleasesTests.swift
+++ b/Tests/OctoKitTests/ReleasesTests.swift
@@ -17,7 +17,7 @@ final class ReleasesTests: XCTestCase {
                                             expectedHTTPMethod: "GET",
                                             jsonFile: "Fixtures/releases",
                                             statusCode: 200)
-        let task = Octokit().listReleases(session, owner: "octocat", repository: "Hello-World") {
+        let task = Octokit(session: session).listReleases(owner: "octocat", repository: "Hello-World") {
             switch $0 {
             case let .success(releases):
                 XCTAssertEqual(releases.count, 2)
@@ -61,7 +61,7 @@ final class ReleasesTests: XCTestCase {
                                             expectedHTTPMethod: "GET",
                                             jsonFile: "Fixtures/releases",
                                             statusCode: 200)
-        let task = Octokit().listReleases(session, owner: "octocat", repository: "Hello-World", perPage: perPage) {
+        let task = Octokit(session: session).listReleases(owner: "octocat", repository: "Hello-World", perPage: perPage) {
             switch $0 {
             case .success:
                 break
@@ -80,7 +80,7 @@ final class ReleasesTests: XCTestCase {
                                             expectedHTTPMethod: "GET",
                                             jsonFile: "Fixtures/releases",
                                             statusCode: 200)
-        let releases = try await Octokit().listReleases(session, owner: "octocat", repository: "Hello-World")
+        let releases = try await Octokit(session: session).listReleases(owner: "octocat", repository: "Hello-World")
         XCTAssertEqual(releases.count, 2)
         if let release = releases.first {
             XCTAssertEqual(release.tagName, "v1.0.0")
@@ -119,7 +119,7 @@ final class ReleasesTests: XCTestCase {
                                             expectedHTTPMethod: "GET",
                                             jsonFile: "Fixtures/latest_release",
                                             statusCode: 200)
-        let release = try await Octokit().getLatestRelease(session, owner: "octocat", repository: "Hello-World")
+        let release = try await Octokit(session: session).getLatestRelease(owner: "octocat", repository: "Hello-World")
         XCTAssertNotNil(release)
 
         XCTAssertEqual(release.tagName, "v1.0.0")
@@ -136,16 +136,15 @@ final class ReleasesTests: XCTestCase {
 
     func testPostRelease() {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/Hello-World/releases", expectedHTTPMethod: "POST", jsonFile: "post_release", statusCode: 201)
-        let task = Octokit().postRelease(session,
-                                         owner: "octocat",
-                                         repository: "Hello-World",
-                                         tagName: "v1.0.0",
-                                         targetCommitish: "master",
-                                         name: "v1.0.0 Release",
-                                         body: "The changelog of this release",
-                                         prerelease: false,
-                                         draft: false,
-                                         generateNotes: false) { response in
+        let task = Octokit(session: session).postRelease(owner: "octocat",
+                                                         repository: "Hello-World",
+                                                         tagName: "v1.0.0",
+                                                         targetCommitish: "master",
+                                                         name: "v1.0.0 Release",
+                                                         body: "The changelog of this release",
+                                                         prerelease: false,
+                                                         draft: false,
+                                                         generateNotes: false) { response in
             switch response {
             case let .success(release):
                 XCTAssertEqual(release.tagName, "v1.0.0")
@@ -167,7 +166,7 @@ final class ReleasesTests: XCTestCase {
                                             expectedHTTPMethod: "GET",
                                             jsonFile: "Fixtures/release",
                                             statusCode: 201)
-        let task = Octokit().release(session, owner: "octocat", repository: "Hello-World", tag: "v1.0.0") {
+        let task = Octokit(session: session).release(owner: "octocat", repository: "Hello-World", tag: "v1.0.0") {
             switch $0 {
             case let .success(release):
                 XCTAssertEqual(release.tagName, "v1.0.0")
@@ -191,16 +190,15 @@ final class ReleasesTests: XCTestCase {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func testPostReleaseAsync() async throws {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/Hello-World/releases", expectedHTTPMethod: "POST", jsonFile: "post_release", statusCode: 201)
-        let release = try await Octokit().postRelease(session,
-                                                      owner: "octocat",
-                                                      repository: "Hello-World",
-                                                      tagName: "v1.0.0",
-                                                      targetCommitish: "master",
-                                                      name: "v1.0.0 Release",
-                                                      body: "The changelog of this release",
-                                                      prerelease: false,
-                                                      draft: false,
-                                                      generateNotes: false)
+        let release = try await Octokit(session: session).postRelease(owner: "octocat",
+                                                                      repository: "Hello-World",
+                                                                      tagName: "v1.0.0",
+                                                                      targetCommitish: "master",
+                                                                      name: "v1.0.0 Release",
+                                                                      body: "The changelog of this release",
+                                                                      prerelease: false,
+                                                                      draft: false,
+                                                                      generateNotes: false)
         XCTAssertEqual(release.tagName, "v1.0.0")
         XCTAssertEqual(release.commitish, "master")
         XCTAssertEqual(release.name, "v1.0.0 Release")

--- a/Tests/OctoKitTests/RepositoryTests.swift
+++ b/Tests/OctoKitTests/RepositoryTests.swift
@@ -6,7 +6,7 @@ class RepositoryTests: XCTestCase {
 
     func testGetRepositories() {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/users/octocat/repos?page=1&per_page=100", expectedHTTPMethod: "GET", jsonFile: "user_repos", statusCode: 200)
-        let task = Octokit().repositories(session, owner: "octocat") { response in
+        let task = Octokit(session: session).repositories(owner: "octocat") { response in
             switch response {
             case let .success(repositories):
                 XCTAssertEqual(repositories.count, 1)
@@ -24,7 +24,7 @@ class RepositoryTests: XCTestCase {
                                             expectedHTTPMethod: "GET",
                                             jsonFile: "user_repos",
                                             statusCode: 200)
-        let task = Octokit(config).repositories(session, owner: "octocat") { response in
+        let task = Octokit(config, session: session).repositories(owner: "octocat") { response in
             switch response {
             case let .success(repositories):
                 XCTAssertEqual(repositories.count, 1)
@@ -45,7 +45,7 @@ class RepositoryTests: XCTestCase {
                                             expectedHTTPHeaders: headers,
                                             jsonFile: "user_repos",
                                             statusCode: 200)
-        let task = Octokit(config).repositories(session) { response in
+        let task = Octokit(config, session: session).repositories { response in
             switch response {
             case let .success(repositories):
                 XCTAssertEqual(repositories.count, 1)
@@ -66,7 +66,7 @@ class RepositoryTests: XCTestCase {
                                             expectedHTTPHeaders: headers,
                                             jsonFile: "user_repos",
                                             statusCode: 200)
-        let task = Octokit(config).repositories(session) { response in
+        let task = Octokit(config, session: session).repositories { response in
             switch response {
             case let .success(repositories):
                 XCTAssertEqual(repositories.count, 1)
@@ -88,7 +88,7 @@ class RepositoryTests: XCTestCase {
                                             expectedHTTPHeaders: headers,
                                             response: json,
                                             statusCode: 401)
-        let task = Octokit(config).repositories(session) { response in
+        let task = Octokit(config, session: session).repositories { response in
             switch response {
             case .success:
                 XCTAssert(false, "should not retrieve repositories")
@@ -105,7 +105,7 @@ class RepositoryTests: XCTestCase {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func testGetRepositoriesAsync() async throws {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/users/octocat/repos?page=1&per_page=100", expectedHTTPMethod: "GET", jsonFile: "user_repos", statusCode: 200)
-        let repositories = try await Octokit().repositories(session, owner: "octocat")
+        let repositories = try await Octokit(session: session).repositories(owner: "octocat")
         XCTAssertEqual(repositories.count, 1)
         XCTAssertTrue(session.wasCalled)
     }
@@ -114,7 +114,7 @@ class RepositoryTests: XCTestCase {
     func testGetRepository() {
         let (owner, name) = ("mietzmithut", "Test")
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/mietzmithut/Test", expectedHTTPMethod: "GET", jsonFile: "repo", statusCode: 200)
-        let task = Octokit().repository(session, owner: owner, name: name) { response in
+        let task = Octokit(session: session).repository(owner: owner, name: name) { response in
             switch response {
             case let .success(repo):
                 XCTAssertEqual(repo.name, name)
@@ -131,7 +131,7 @@ class RepositoryTests: XCTestCase {
         let config = TokenConfiguration(url: "https://enterprise.nerdishbynature.com/api/v3/")
         let (owner, name) = ("mietzmithut", "Test")
         let session = OctoKitURLTestSession(expectedURL: "https://enterprise.nerdishbynature.com/api/v3/repos/mietzmithut/Test", expectedHTTPMethod: "GET", jsonFile: "repo", statusCode: 200)
-        let task = Octokit(config).repository(session, owner: owner, name: name) { response in
+        let task = Octokit(config, session: session).repository(owner: owner, name: name) { response in
             switch response {
             case let .success(repo):
                 XCTAssertEqual(repo.name, name)
@@ -147,7 +147,7 @@ class RepositoryTests: XCTestCase {
     func testFailToGetRepository() {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/mietzmithut/Test", expectedHTTPMethod: "GET", jsonFile: nil, statusCode: 404)
         let (owner, name) = ("mietzmithut", "Test")
-        let task = Octokit().repository(session, owner: owner, name: name) { response in
+        let task = Octokit(session: session).repository(owner: owner, name: name) { response in
             switch response {
             case .success:
                 XCTAssert(false, "should not retrieve repositories")
@@ -165,7 +165,7 @@ class RepositoryTests: XCTestCase {
     func testGetRepositoryAsync() async throws {
         let (owner, name) = ("mietzmithut", "Test")
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/mietzmithut/Test", expectedHTTPMethod: "GET", jsonFile: "repo", statusCode: 200)
-        let repo = try await Octokit().repository(session, owner: owner, name: name)
+        let repo = try await Octokit(session: session).repository(owner: owner, name: name)
         XCTAssertEqual(repo.name, name)
         XCTAssertEqual(repo.owner.login, owner)
         XCTAssertTrue(session.wasCalled)

--- a/Tests/OctoKitTests/ReviewTests.swift
+++ b/Tests/OctoKitTests/ReviewTests.swift
@@ -12,7 +12,7 @@ import XCTest
 class ReviewTests: XCTestCase {
     func testReviews() {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/Hello-World/pulls/1/reviews", expectedHTTPMethod: "GET", jsonFile: "reviews", statusCode: 201)
-        let task = Octokit().listReviews(session, owner: "octocat", repository: "Hello-World", pullRequestNumber: 1) { response in
+        let task = Octokit(session: session).listReviews(owner: "octocat", repository: "Hello-World", pullRequestNumber: 1) { response in
             switch response {
             case let .success(reviews):
                 let review = reviews.first
@@ -46,7 +46,7 @@ class ReviewTests: XCTestCase {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func testReviewsAsync() async throws {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/Hello-World/pulls/1/reviews", expectedHTTPMethod: "GET", jsonFile: "reviews", statusCode: 201)
-        let reviews = try await Octokit().reviews(session, owner: "octocat", repository: "Hello-World", pullRequestNumber: 1)
+        let reviews = try await Octokit(session: session).reviews(owner: "octocat", repository: "Hello-World", pullRequestNumber: 1)
         let review = reviews.first
         XCTAssertEqual(review?.body, "Here is the body for the review.")
         XCTAssertEqual(review?.commitID, "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091")
@@ -72,11 +72,10 @@ class ReviewTests: XCTestCase {
 
     func testPostReview() {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/Hello-World/pulls/1/reviews", expectedHTTPMethod: "POST", jsonFile: "review", statusCode: 200)
-        let task = Octokit().postReview(session,
-                                        owner: "octocat",
-                                        repository: "Hello-World",
-                                        pullRequestNumber: 1,
-                                        event: .approve) {
+        let task = Octokit(session: session).postReview(owner: "octocat",
+                                                        repository: "Hello-World",
+                                                        pullRequestNumber: 1,
+                                                        event: .approve) {
             switch $0 {
             case let .success(review):
                 XCTAssertEqual(review.body, "Here is the body for the review.")
@@ -109,11 +108,10 @@ class ReviewTests: XCTestCase {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func testPostReviewAsync() async throws {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/Hello-World/pulls/1/reviews", expectedHTTPMethod: "POST", jsonFile: "review", statusCode: 200)
-        let review = try await Octokit().postReview(session,
-                                                    owner: "octocat",
-                                                    repository: "Hello-World",
-                                                    pullRequestNumber: 1,
-                                                    event: .approve)
+        let review = try await Octokit(session: session).postReview(owner: "octocat",
+                                                                    repository: "Hello-World",
+                                                                    pullRequestNumber: 1,
+                                                                    event: .approve)
         XCTAssertEqual(review.body, "Here is the body for the review.")
         XCTAssertEqual(review.commitID, "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091")
         XCTAssertEqual(review.id, 80)

--- a/Tests/OctoKitTests/StarsTests.swift
+++ b/Tests/OctoKitTests/StarsTests.swift
@@ -9,7 +9,7 @@ class StarsTests: XCTestCase {
         let headers = Helper.makeAuthHeader(username: "user", password: "12345")
 
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/user/starred", expectedHTTPMethod: "GET", expectedHTTPHeaders: headers, jsonFile: "user_repos", statusCode: 200)
-        let task = Octokit(config).myStars(session) { response in
+        let task = Octokit(config, session: session).myStars { response in
             switch response {
             case let .success(repositories):
                 XCTAssertEqual(repositories.count, 1)
@@ -26,7 +26,7 @@ class StarsTests: XCTestCase {
         let headers = Helper.makeAuthHeader(username: "user", password: "12345")
 
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/user/starred", expectedHTTPMethod: "GET", expectedHTTPHeaders: headers, jsonFile: nil, statusCode: 404)
-        let task = Octokit(config).myStars(session) { response in
+        let task = Octokit(config, session: session).myStars { response in
             switch response {
             case .success:
                 XCTAssert(false, "should not retrieve repositories")
@@ -41,7 +41,7 @@ class StarsTests: XCTestCase {
 
     func testGetUsersStarredRepositories() {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/users/octocat/starred", expectedHTTPMethod: "GET", jsonFile: "user_repos", statusCode: 200)
-        let task = Octokit().stars(session, name: "octocat") { response in
+        let task = Octokit(session: session).stars(name: "octocat") { response in
             switch response {
             case let .success(repositories):
                 XCTAssertEqual(repositories.count, 1)
@@ -55,7 +55,7 @@ class StarsTests: XCTestCase {
 
     func testFailToGetUsersStarredRepositories() {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/users/octocat/starred", expectedHTTPMethod: "GET", jsonFile: nil, statusCode: 404)
-        let task = Octokit().stars(session, name: "octocat") { response in
+        let task = Octokit(session: session).stars(name: "octocat") { response in
             switch response {
             case .success:
                 XCTAssert(false, "should not retrieve repositories")
@@ -70,9 +70,7 @@ class StarsTests: XCTestCase {
 
     func testGetStarFromNotStarredRepository() {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/user/starred/octocat/Hello-World", expectedHTTPMethod: "GET", jsonFile: nil, statusCode: 404)
-        let task = Octokit().star(session,
-                                  owner: "octocat",
-                                  repository: "Hello-World") { response in
+        let task = Octokit(session: session).star(owner: "octocat", repository: "Hello-World") { response in
             switch response {
             case let .success(flag):
                 XCTAssertFalse(flag)
@@ -86,9 +84,7 @@ class StarsTests: XCTestCase {
 
     func testGetStarFromStarredRepository() {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/user/starred/octocat/Hello-World", expectedHTTPMethod: "GET", jsonFile: nil, statusCode: 204)
-        let task = Octokit().star(session,
-                                  owner: "octocat",
-                                  repository: "Hello-World") { response in
+        let task = Octokit(session: session).star(owner: "octocat", repository: "Hello-World") { response in
             switch response {
             case let .success(flag):
                 XCTAssertTrue(flag)
@@ -102,9 +98,7 @@ class StarsTests: XCTestCase {
 
     func testPutStar() {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/user/starred/octocat/Hello-World", expectedHTTPMethod: "PUT", jsonFile: nil, statusCode: 204)
-        let task = Octokit().putStar(session,
-                                     owner: "octocat",
-                                     repository: "Hello-World") { response in
+        let task = Octokit(session: session).putStar(owner: "octocat", repository: "Hello-World") { response in
             XCTAssertNil(response)
         }
         XCTAssertNotNil(task)
@@ -113,9 +107,7 @@ class StarsTests: XCTestCase {
 
     func testDeleteStar() {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/user/starred/octocat/Hello-World", expectedHTTPMethod: "DELETE", jsonFile: nil, statusCode: 204)
-        let task = Octokit().deleteStar(session,
-                                        owner: "octocat",
-                                        repository: "Hello-World") { response in
+        let task = Octokit(session: session).deleteStar(owner: "octocat", repository: "Hello-World") { response in
             XCTAssertNil(response)
         }
         XCTAssertNotNil(task)
@@ -131,49 +123,41 @@ extension StarsTests {
         let headers = Helper.makeAuthHeader(username: "user", password: "12345")
 
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/user/starred", expectedHTTPMethod: "GET", expectedHTTPHeaders: headers, jsonFile: "user_repos", statusCode: 200)
-        let repositories = try await Octokit(config).myStars(session)
+        let repositories = try await Octokit(config, session: session).myStars()
         XCTAssertEqual(repositories.count, 1)
         XCTAssertTrue(session.wasCalled)
     }
 
     func testGetUsersStarredRepositoriesAsync() async throws {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/users/octocat/starred", expectedHTTPMethod: "GET", jsonFile: "user_repos", statusCode: 200)
-        let repositories = try await Octokit().stars(session, name: "octocat")
+        let repositories = try await Octokit(session: session).stars(name: "octocat")
         XCTAssertEqual(repositories.count, 1)
         XCTAssertTrue(session.wasCalled)
     }
 
     func testGetStarFromNotStarredRepositoryAsync() async throws {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/user/starred/octocat/Hello-World", expectedHTTPMethod: "GET", jsonFile: nil, statusCode: 404)
-        let flag = try await Octokit().star(session,
-                                            owner: "octocat",
-                                            repository: "Hello-World")
+        let flag = try await Octokit(session: session).star(owner: "octocat", repository: "Hello-World")
         XCTAssertFalse(flag)
         XCTAssertTrue(session.wasCalled)
     }
 
     func testGetStarFromStarredRepositoryAsync() async throws {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/user/starred/octocat/Hello-World", expectedHTTPMethod: "GET", jsonFile: nil, statusCode: 204)
-        let flag = try await Octokit().star(session,
-                                            owner: "octocat",
-                                            repository: "Hello-World")
+        let flag = try await Octokit(session: session).star(owner: "octocat", repository: "Hello-World")
         XCTAssertTrue(flag)
         XCTAssertTrue(session.wasCalled)
     }
 
     func testPutStarAsync() async throws {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/user/starred/octocat/Hello-World", expectedHTTPMethod: "PUT", jsonFile: nil, statusCode: 204)
-        try await Octokit().putStar(session,
-                                    owner: "octocat",
-                                    repository: "Hello-World")
+        try await Octokit(session: session).putStar(owner: "octocat", repository: "Hello-World")
         XCTAssertTrue(session.wasCalled)
     }
 
     func testDeleteStarAsync() async throws {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/user/starred/octocat/Hello-World", expectedHTTPMethod: "DELETE", jsonFile: nil, statusCode: 204)
-        try await Octokit().deleteStar(session,
-                                       owner: "octocat",
-                                       repository: "Hello-World")
+        try await Octokit(session: session).deleteStar(owner: "octocat", repository: "Hello-World")
         XCTAssertTrue(session.wasCalled)
     }
 }

--- a/Tests/OctoKitTests/StatusesTests.swift
+++ b/Tests/OctoKitTests/StatusesTests.swift
@@ -10,14 +10,13 @@ class StatusesTests: XCTestCase {
                                             jsonFile: "status",
                                             statusCode: 201)
 
-        let task = Octokit().createCommitStatus(session,
-                                                owner: "octocat",
-                                                repository: "Hello-World",
-                                                sha: "6dcb09b5b57875f334f61aebed695e2e4193db5e",
-                                                state: .success,
-                                                targetURL: "https://example.com/build/status",
-                                                description: "The build succeeded!",
-                                                context: "continuous-integration/jenkins") { response in
+        let task = Octokit(session: session).createCommitStatus(owner: "octocat",
+                                                                repository: "Hello-World",
+                                                                sha: "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+                                                                state: .success,
+                                                                targetURL: "https://example.com/build/status",
+                                                                description: "The build succeeded!",
+                                                                context: "continuous-integration/jenkins") { response in
             switch response {
             case let .success(status):
                 XCTAssertEqual(status.id, 1)
@@ -45,14 +44,13 @@ class StatusesTests: XCTestCase {
                                             jsonFile: "status",
                                             statusCode: 201)
 
-        let status = try await Octokit().createCommitStatus(session,
-                                                            owner: "octocat",
-                                                            repository: "Hello-World",
-                                                            sha: "6dcb09b5b57875f334f61aebed695e2e4193db5e",
-                                                            state: .success,
-                                                            targetURL: "https://example.com/build/status",
-                                                            description: "The build succeeded!",
-                                                            context: "continuous-integration/jenkins")
+        let status = try await Octokit(session: session).createCommitStatus(owner: "octocat",
+                                                                            repository: "Hello-World",
+                                                                            sha: "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+                                                                            state: .success,
+                                                                            targetURL: "https://example.com/build/status",
+                                                                            description: "The build succeeded!",
+                                                                            context: "continuous-integration/jenkins")
         XCTAssertEqual(status.id, 1)
         XCTAssertEqual(status.url, "https://api.github.com/repos/octocat/Hello-World/statuses/6dcb09b5b57875f334f61aebed695e2e4193db5e")
         XCTAssertEqual(status.avatarURL, "https://github.com/images/error/hubot_happy.gif")
@@ -72,7 +70,7 @@ class StatusesTests: XCTestCase {
                                             jsonFile: "statuses",
                                             statusCode: 200)
 
-        let task = Octokit().listCommitStatuses(session, owner: "octocat", repository: "Hello-World", ref: "6dcb09b5b57875f334f61aebed695e2e4193db5e") { response in
+        let task = Octokit(session: session).listCommitStatuses(owner: "octocat", repository: "Hello-World", ref: "6dcb09b5b57875f334f61aebed695e2e4193db5e") { response in
             switch response {
             case let .success(statuses):
                 XCTAssertEqual(statuses.count, 1)
@@ -101,7 +99,7 @@ class StatusesTests: XCTestCase {
                                             jsonFile: "statuses",
                                             statusCode: 200)
 
-        let statuses = try await Octokit().listCommitStatuses(session, owner: "octocat", repository: "Hello-World", ref: "6dcb09b5b57875f334f61aebed695e2e4193db5e")
+        let statuses = try await Octokit(session: session).listCommitStatuses(owner: "octocat", repository: "Hello-World", ref: "6dcb09b5b57875f334f61aebed695e2e4193db5e")
         XCTAssertEqual(statuses.count, 1)
         XCTAssertEqual(statuses.first?.id, 1)
         XCTAssertEqual(statuses.first?.url, "https://api.github.com/repos/octocat/Hello-World/statuses/6dcb09b5b57875f334f61aebed695e2e4193db5e")

--- a/Tests/OctoKitTests/UserTests.swift
+++ b/Tests/OctoKitTests/UserTests.swift
@@ -7,7 +7,7 @@ class UserTests: XCTestCase {
     func testGetUser() {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/users/mietzmithut", expectedHTTPMethod: "GET", jsonFile: "user_mietzmithut", statusCode: 200)
         let username = "mietzmithut"
-        let task = Octokit().user(session, name: username) { response in
+        let task = Octokit(session: session).user(name: username) { response in
             switch response {
             case let .success(user):
                 XCTAssertEqual(user.login, username)
@@ -23,7 +23,7 @@ class UserTests: XCTestCase {
     func testFailingToGetUser() {
         let username = "notexisting"
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/users/notexisting", expectedHTTPMethod: "GET", jsonFile: nil, statusCode: 404)
-        let task = Octokit().user(session, name: username) { response in
+        let task = Octokit(session: session).user(name: username) { response in
             switch response {
             case .success:
                 XCTAssert(false, "should not retrieve user")
@@ -41,7 +41,7 @@ class UserTests: XCTestCase {
     func testGetUserAsync() async throws {
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/users/mietzmithut", expectedHTTPMethod: "GET", jsonFile: "user_mietzmithut", statusCode: 200)
         let username = "mietzmithut"
-        let user = try await Octokit().user(session, name: username)
+        let user = try await Octokit(session: session).user(name: username)
         XCTAssertEqual(user.login, username)
         XCTAssertNotNil(user.createdAt)
         XCTAssertTrue(session.wasCalled)
@@ -53,7 +53,7 @@ class UserTests: XCTestCase {
         let headers = Helper.makeAuthHeader(username: "user", password: "12345")
 
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/user", expectedHTTPMethod: "GET", expectedHTTPHeaders: headers, jsonFile: "user_me", statusCode: 200)
-        let task = Octokit(config).me(session) { response in
+        let task = Octokit(config, session: session).me { response in
             switch response {
             case let .success(user):
                 XCTAssertEqual(user.login, "pietbrauer")
@@ -68,7 +68,7 @@ class UserTests: XCTestCase {
     func testFailToGetAuthenticatedUser() {
         let json = "{\"message\":\"Bad credentials\",\"documentation_url\":\"https://developer.github.com/v3\"}"
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/user", expectedHTTPMethod: "GET", response: json, statusCode: 401)
-        let task = Octokit().me(session) { response in
+        let task = Octokit(session: session).me { response in
             switch response {
             case .success:
                 XCTAssert(false, "should not retrieve user")
@@ -88,7 +88,7 @@ class UserTests: XCTestCase {
         let headers = Helper.makeAuthHeader(username: "user", password: "12345")
 
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/user", expectedHTTPMethod: "GET", expectedHTTPHeaders: headers, jsonFile: "user_me", statusCode: 200)
-        let user = try await Octokit(config).me(session)
+        let user = try await Octokit(config, session: session).me()
         XCTAssertEqual(user.login, "pietbrauer")
         XCTAssertTrue(session.wasCalled)
     }


### PR DESCRIPTION
I have no idea why I did it back in the day but it's kind of cumbersome to provide the session to every method instead of having it defined once in your application.