### PR TITLE
add missing ci_activity to notification reasons

### DIFF
--- a/OctoKit/NotificationThread.swift
+++ b/OctoKit/NotificationThread.swift
@@ -43,6 +43,7 @@ open class NotificationThread: Codable {
     public enum Reason: String, Codable {
         case assign
         case author
+        case ciActivity = "ci_activity"
         case comment
         case invitation
         case manual


### PR DESCRIPTION
According to [the GitHub docs for notifications](https://docs.github.com/en/rest/activity/notifications?apiVersion=2022-11-28#about-notification-reasons), the Reason enum contains all cases except `ci_activity`, so I think we can just add it here?