### PR TITLE
Async notifications support + added endpoints

### DIFF
--- a/OctoKit/NotificationThread.swift
+++ b/OctoKit/NotificationThread.swift
@@ -25,8 +25,7 @@ open class NotificationThread: Codable {
                 url: String? = nil,
                 subscriptionUrl: String? = nil,
                 subject: NotificationThread.Subject = Subject(),
-                repository: Repository = Repository())
-    {
+                repository: Repository = Repository()) {
         self.id = id
         self.unread = unread
         self.reason = reason
@@ -121,8 +120,7 @@ public extension Octokit {
                          participating: Bool = false,
                          page: String = "1",
                          perPage: String = "100",
-                         completion: @escaping (_ response: Result<[NotificationThread], Error>) -> Void) -> URLSessionDataTaskProtocol?
-    {
+                         completion: @escaping (_ response: Result<[NotificationThread], Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = NotificationRouter.readNotifications(configuration, all, participating, page, perPage)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [NotificationThread].self) { notifications, error in
             if let error = error {
@@ -144,12 +142,10 @@ public extension Octokit {
      - parameter perPage: Number of notifications per page. `100` by default.
      */
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func myNotifications(
-        all: Bool = false,
-        participating: Bool = false,
-        page: String = "1",
-        perPage: String = "100"
-    ) async throws -> [NotificationThread] {
+    func myNotifications(all: Bool = false,
+                         participating: Bool = false,
+                         page: String = "1",
+                         perPage: String = "100") async throws -> [NotificationThread] {
         let router = NotificationRouter.readNotifications(configuration, all, participating, page, perPage)
         return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [NotificationThread].self)
     }
@@ -164,8 +160,7 @@ public extension Octokit {
     @discardableResult
     func markNotificationsRead(lastReadAt: String = "last_read_at",
                                read: Bool = false,
-                               completion: @escaping (_ response: Error?) -> Void) -> URLSessionDataTaskProtocol?
-    {
+                               completion: @escaping (_ response: Error?) -> Void) -> URLSessionDataTaskProtocol? {
         let router = NotificationRouter.markNotificationsRead(configuration, lastReadAt, read)
         return router.load(session, completion: completion)
     }
@@ -177,10 +172,8 @@ public extension Octokit {
      - parameter read: Whether the notification has been read `false` by default.
      */
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func markNotificationsRead(
-        lastReadAt: String = "last_read_at",
-        read: Bool = false
-    ) async throws {
+    func markNotificationsRead(lastReadAt: String = "last_read_at",
+                               read: Bool = false) async throws {
         let router = NotificationRouter.markNotificationsRead(configuration, lastReadAt, read)
         return try await router.load(session)
     }
@@ -193,8 +186,7 @@ public extension Octokit {
      */
     @discardableResult
     func markNotificationThreadAsRead(threadId: String,
-                                      completion: @escaping (_ response: Error?) -> Void) -> URLSessionDataTaskProtocol?
-    {
+                                      completion: @escaping (_ response: Error?) -> Void) -> URLSessionDataTaskProtocol? {
         let router = NotificationRouter.markNotificationThreadAsRead(configuration, threadId)
         return router.load(session, completion: completion)
     }
@@ -205,9 +197,7 @@ public extension Octokit {
      - parameter threadId: The ID of the Thread.
      */
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func markNotificationThreadAsRead(
-        threadId: String
-    ) async throws {
+    func markNotificationThreadAsRead(threadId: String) async throws {
         let router = NotificationRouter.markNotificationThreadAsRead(configuration, threadId)
         return try await router.load(session)
     }
@@ -220,8 +210,7 @@ public extension Octokit {
      */
     @discardableResult
     func markNotificationThreadAsDone(threadId: String,
-                                      completion: @escaping (_ response: Error?) -> Void) -> URLSessionDataTaskProtocol?
-    {
+                                      completion: @escaping (_ response: Error?) -> Void) -> URLSessionDataTaskProtocol? {
         let router = NotificationRouter.markNotificationThreadAsDone(configuration, threadId)
         return router.load(session, completion: completion)
     }
@@ -232,9 +221,7 @@ public extension Octokit {
      - parameter threadId: The ID of the Thread.
      */
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func markNotificationThreadAsDone(
-        threadId: String
-    ) async throws {
+    func markNotificationThreadAsDone(threadId: String) async throws {
         let router = NotificationRouter.markNotificationThreadAsDone(configuration, threadId)
         return try await router.load(session)
     }
@@ -247,8 +234,7 @@ public extension Octokit {
      */
     @discardableResult
     func getNotificationThread(threadId: String,
-                               completion: @escaping (_ response: Result<NotificationThread, Error>) -> Void) -> URLSessionDataTaskProtocol?
-    {
+                               completion: @escaping (_ response: Result<NotificationThread, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = NotificationRouter.getNotificationThread(configuration, threadId)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: NotificationThread.self) { notification, error in
             if let error = error {
@@ -267,9 +253,7 @@ public extension Octokit {
      - parameter threadId: The ID of the Thread.
      */
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func getNotificationThread(
-        threadId: String
-    ) async throws -> NotificationThread {
+    func getNotificationThread(threadId: String) async throws -> NotificationThread {
         let router = NotificationRouter.getNotificationThread(configuration, threadId)
         return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: NotificationThread.self)
     }
@@ -282,8 +266,7 @@ public extension Octokit {
       */
     @discardableResult
     func getThreadSubscription(threadId: String,
-                               completion: @escaping (_ response: Result<ThreadSubscription, Error>) -> Void) -> URLSessionDataTaskProtocol?
-    {
+                               completion: @escaping (_ response: Result<ThreadSubscription, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = NotificationRouter.getThreadSubscription(configuration, threadId)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: ThreadSubscription.self) { thread, error in
             if let error = error {
@@ -302,9 +285,7 @@ public extension Octokit {
       - parameter threadId: The ID of the Thread.
       */
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func getThreadSubscription(
-        threadId: String
-    ) async throws -> ThreadSubscription {
+    func getThreadSubscription(threadId: String) async throws -> ThreadSubscription {
         let router = NotificationRouter.getThreadSubscription(configuration, threadId)
         return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: ThreadSubscription.self)
     }
@@ -319,8 +300,7 @@ public extension Octokit {
     @discardableResult
     func setThreadSubscription(threadId: String,
                                ignored: Bool = false,
-                               completion: @escaping (_ response: Result<ThreadSubscription, Error>) -> Void) -> URLSessionDataTaskProtocol?
-    {
+                               completion: @escaping (_ response: Result<ThreadSubscription, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = NotificationRouter.setThreadSubscription(configuration, threadId, ignored)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: ThreadSubscription.self) { thread, error in
             if let error = error {
@@ -340,10 +320,8 @@ public extension Octokit {
      - parameter ignored: Whether to block all notifications from a thread `false` by default.
      */
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func setThreadSubscription(
-        threadId: String,
-        ignored: Bool = false
-    ) async throws -> ThreadSubscription {
+    func setThreadSubscription(threadId: String,
+                               ignored: Bool = false) async throws -> ThreadSubscription {
         let router = NotificationRouter.setThreadSubscription(configuration, threadId, ignored)
         return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: ThreadSubscription.self)
     }
@@ -393,8 +371,7 @@ public extension Octokit {
                                      before: String? = nil,
                                      page: String = "1",
                                      perPage: String = "100",
-                                     completion: @escaping (_ response: Result<[NotificationThread], Error>) -> Void) -> URLSessionDataTaskProtocol?
-    {
+                                     completion: @escaping (_ response: Result<[NotificationThread], Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = NotificationRouter.listRepositoryNotifications(configuration, owner, repository, all, participating, since, before, perPage, page)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [NotificationThread].self) { notifications, error in
             if let error = error {
@@ -420,16 +397,14 @@ public extension Octokit {
      - parameter perPage: Number of notifications per page. `100` by default.
      */
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func listRepositoryNotifications(
-        owner: String,
-        repository: String,
-        all: Bool = false,
-        participating: Bool = false,
-        since: String? = nil,
-        before: String? = nil,
-        page: String = "1",
-        perPage: String = "100"
-    ) async throws -> [NotificationThread] {
+    func listRepositoryNotifications(owner: String,
+                                     repository: String,
+                                     all: Bool = false,
+                                     participating: Bool = false,
+                                     since: String? = nil,
+                                     before: String? = nil,
+                                     page: String = "1",
+                                     perPage: String = "100") async throws -> [NotificationThread] {
         let router = NotificationRouter.listRepositoryNotifications(configuration, owner, repository, all, participating, since, before, perPage, page)
         return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [NotificationThread].self)
     }
@@ -446,8 +421,7 @@ public extension Octokit {
     func markRepositoryNotificationsRead(owner: String,
                                          repository: String,
                                          lastReadAt: String? = nil,
-                                         completion: @escaping (_ response: Error?) -> Void) -> URLSessionDataTaskProtocol?
-    {
+                                         completion: @escaping (_ response: Error?) -> Void) -> URLSessionDataTaskProtocol? {
         let router = NotificationRouter.markRepositoryNotificationsRead(configuration, owner, repository, lastReadAt)
         return router.load(session, completion: completion)
     }
@@ -460,11 +434,9 @@ public extension Octokit {
      - parameter lastReadAt: Describes the last point that notifications were checked `last_read_at` by default.
      */
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func markRepositoryNotificationsRead(
-        owner: String,
-        repository: String,
-        lastReadAt: String? = nil
-    ) async throws {
+    func markRepositoryNotificationsRead(owner: String,
+                                         repository: String,
+                                         lastReadAt: String? = nil) async throws {
         let router = NotificationRouter.markRepositoryNotificationsRead(configuration, owner, repository, lastReadAt)
         return try await router.load(session)
     }
@@ -551,7 +523,7 @@ enum NotificationRouter: Router {
             return ["last_read_at": lastReadAt, "read": "\(read)"]
         case .getNotificationThread:
             return [:]
-        case .markNotificationThreadAsRead(_, _):
+        case .markNotificationThreadAsRead:
             return [:]
         case .markNotificationThreadAsDone:
             return [:]

--- a/OctoKit/NotificationThread.swift
+++ b/OctoKit/NotificationThread.swift
@@ -551,9 +551,9 @@ enum NotificationRouter: Router {
             return ["last_read_at": lastReadAt, "read": "\(read)"]
         case .getNotificationThread:
             return [:]
-        case let .markNotificationThreadAsRead(_, threadID):
+        case .markNotificationThreadAsRead(_, _):
             return [:]
-        case let .markNotificationThreadAsDone:
+        case .markNotificationThreadAsDone:
             return [:]
         case .getThreadSubscription:
             return [:]

--- a/OctoKit/NotificationThread.swift
+++ b/OctoKit/NotificationThread.swift
@@ -17,6 +17,27 @@ open class NotificationThread: Codable {
     open private(set) var subject = Subject()
     open private(set) var repository = Repository()
 
+    public init(id: String,
+                unread: Bool? = nil,
+                reason: Reason? = nil,
+                updatedAt: Date? = nil,
+                lastReadAt: Date? = nil,
+                url: String? = nil,
+                subscriptionUrl: String? = nil,
+                subject: NotificationThread.Subject = Subject(),
+                repository: Repository = Repository())
+    {
+        self.id = id
+        self.unread = unread
+        self.reason = reason
+        self.updatedAt = updatedAt
+        self.lastReadAt = lastReadAt
+        self.url = url
+        self.subscriptionUrl = subscriptionUrl
+        self.subject = subject
+        self.repository = repository
+    }
+
     enum CodingKeys: String, CodingKey {
         case id
         case unread
@@ -34,6 +55,13 @@ open class NotificationThread: Codable {
         open var url: String?
         open var latestCommentUrl: String?
         open var type: String?
+
+        public init(title: String? = nil, url: String? = nil, latestCommentUrl: String? = nil, type: String? = nil) {
+            self.title = title
+            self.url = url
+            self.latestCommentUrl = latestCommentUrl
+            self.type = type
+        }
 
         enum CodingKeys: String, CodingKey {
             case title
@@ -93,7 +121,8 @@ public extension Octokit {
                          participating: Bool = false,
                          page: String = "1",
                          perPage: String = "100",
-                         completion: @escaping (_ response: Result<[NotificationThread], Error>) -> Void) -> URLSessionDataTaskProtocol? {
+                         completion: @escaping (_ response: Result<[NotificationThread], Error>) -> Void) -> URLSessionDataTaskProtocol?
+    {
         let router = NotificationRouter.readNotifications(configuration, all, participating, page, perPage)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [NotificationThread].self) { notifications, error in
             if let error = error {
@@ -105,7 +134,7 @@ public extension Octokit {
             }
         }
     }
-    
+
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     /**
      List all notifications for the current user, sorted by most recently updated.
@@ -135,11 +164,12 @@ public extension Octokit {
     @discardableResult
     func markNotificationsRead(lastReadAt: String = "last_read_at",
                                read: Bool = false,
-                               completion: @escaping (_ response: Error?) -> Void) -> URLSessionDataTaskProtocol? {
+                               completion: @escaping (_ response: Error?) -> Void) -> URLSessionDataTaskProtocol?
+    {
         let router = NotificationRouter.markNotificationsRead(configuration, lastReadAt, read)
         return router.load(session, completion: completion)
     }
-    
+
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     /**
      Marks All Notifications As read
@@ -150,13 +180,12 @@ public extension Octokit {
     func markNotificationsRead(
         lastReadAt: String = "last_read_at",
         read: Bool = false
-    ) async throws -> Void {
+    ) async throws {
         let router = NotificationRouter.markNotificationsRead(configuration, lastReadAt, read)
         return try await router.load(session)
     }
     #endif
-    
-    
+
     /**
      Marks a Notification Thread as read
      - parameter threadId: The ID of the Thread.
@@ -164,11 +193,12 @@ public extension Octokit {
      */
     @discardableResult
     func markNotificationThreadAsRead(threadId: String,
-                               completion: @escaping (_ response: Error?) -> Void) -> URLSessionDataTaskProtocol? {
+                                      completion: @escaping (_ response: Error?) -> Void) -> URLSessionDataTaskProtocol?
+    {
         let router = NotificationRouter.markNotificationThreadAsRead(configuration, threadId)
         return router.load(session, completion: completion)
     }
-    
+
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     /**
      Marks a Notification Thread as read
@@ -177,13 +207,12 @@ public extension Octokit {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func markNotificationThreadAsRead(
         threadId: String
-    ) async throws -> Void {
+    ) async throws {
         let router = NotificationRouter.markNotificationThreadAsRead(configuration, threadId)
         return try await router.load(session)
     }
     #endif
-    
-    
+
     /**
      Marks a Notification Thread as done
      - parameter threadId: The ID of the Thread.
@@ -191,11 +220,12 @@ public extension Octokit {
      */
     @discardableResult
     func markNotificationThreadAsDone(threadId: String,
-                               completion: @escaping (_ response: Error?) -> Void) -> URLSessionDataTaskProtocol? {
+                                      completion: @escaping (_ response: Error?) -> Void) -> URLSessionDataTaskProtocol?
+    {
         let router = NotificationRouter.markNotificationThreadAsDone(configuration, threadId)
         return router.load(session, completion: completion)
     }
-    
+
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     /**
      Marks a Notification Thread as done
@@ -204,12 +234,11 @@ public extension Octokit {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func markNotificationThreadAsDone(
         threadId: String
-    ) async throws -> Void {
+    ) async throws {
         let router = NotificationRouter.markNotificationThreadAsDone(configuration, threadId)
         return try await router.load(session)
     }
     #endif
-    
 
     /**
      Retrives a Notification Thread
@@ -218,7 +247,8 @@ public extension Octokit {
      */
     @discardableResult
     func getNotificationThread(threadId: String,
-                               completion: @escaping (_ response: Result<NotificationThread, Error>) -> Void) -> URLSessionDataTaskProtocol? {
+                               completion: @escaping (_ response: Result<NotificationThread, Error>) -> Void) -> URLSessionDataTaskProtocol?
+    {
         let router = NotificationRouter.getNotificationThread(configuration, threadId)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: NotificationThread.self) { notification, error in
             if let error = error {
@@ -230,7 +260,7 @@ public extension Octokit {
             }
         }
     }
-    
+
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     /**
      Retrives a Notification Thread
@@ -252,7 +282,8 @@ public extension Octokit {
       */
     @discardableResult
     func getThreadSubscription(threadId: String,
-                               completion: @escaping (_ response: Result<ThreadSubscription, Error>) -> Void) -> URLSessionDataTaskProtocol? {
+                               completion: @escaping (_ response: Result<ThreadSubscription, Error>) -> Void) -> URLSessionDataTaskProtocol?
+    {
         let router = NotificationRouter.getThreadSubscription(configuration, threadId)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: ThreadSubscription.self) { thread, error in
             if let error = error {
@@ -264,7 +295,7 @@ public extension Octokit {
             }
         }
     }
-    
+
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     /**
      Get a thread subscription for the authenticated user
@@ -288,7 +319,8 @@ public extension Octokit {
     @discardableResult
     func setThreadSubscription(threadId: String,
                                ignored: Bool = false,
-                               completion: @escaping (_ response: Result<ThreadSubscription, Error>) -> Void) -> URLSessionDataTaskProtocol? {
+                               completion: @escaping (_ response: Result<ThreadSubscription, Error>) -> Void) -> URLSessionDataTaskProtocol?
+    {
         let router = NotificationRouter.setThreadSubscription(configuration, threadId, ignored)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: ThreadSubscription.self) { thread, error in
             if let error = error {
@@ -300,7 +332,7 @@ public extension Octokit {
             }
         }
     }
-    
+
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     /**
      Sets a thread subscription for the authenticated user
@@ -327,14 +359,14 @@ public extension Octokit {
         let router = NotificationRouter.deleteThreadSubscription(configuration, threadId)
         return router.load(session, completion: completion)
     }
-    
+
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     /**
      Delete a thread subscription
      - parameter threadId: The ID of the Thread.
      */
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func deleteThreadSubscription(threadId: String) async throws -> Void {
+    func deleteThreadSubscription(threadId: String) async throws {
         let router = NotificationRouter.deleteThreadSubscription(configuration, threadId)
         return try await router.load(session)
     }
@@ -361,7 +393,8 @@ public extension Octokit {
                                      before: String? = nil,
                                      page: String = "1",
                                      perPage: String = "100",
-                                     completion: @escaping (_ response: Result<[NotificationThread], Error>) -> Void) -> URLSessionDataTaskProtocol? {
+                                     completion: @escaping (_ response: Result<[NotificationThread], Error>) -> Void) -> URLSessionDataTaskProtocol?
+    {
         let router = NotificationRouter.listRepositoryNotifications(configuration, owner, repository, all, participating, since, before, perPage, page)
         return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [NotificationThread].self) { notifications, error in
             if let error = error {
@@ -373,7 +406,7 @@ public extension Octokit {
             }
         }
     }
-    
+
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     /**
      List all repository notifications for the current user, sorted by most recently updated.
@@ -389,12 +422,12 @@ public extension Octokit {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func listRepositoryNotifications(
         owner: String,
-                                         repository: String,
-                                         all: Bool = false,
-                                         participating: Bool = false,
-                                         since: String? = nil,
-                                         before: String? = nil,
-                                         page: String = "1",
+        repository: String,
+        all: Bool = false,
+        participating: Bool = false,
+        since: String? = nil,
+        before: String? = nil,
+        page: String = "1",
         perPage: String = "100"
     ) async throws -> [NotificationThread] {
         let router = NotificationRouter.listRepositoryNotifications(configuration, owner, repository, all, participating, since, before, perPage, page)
@@ -413,11 +446,12 @@ public extension Octokit {
     func markRepositoryNotificationsRead(owner: String,
                                          repository: String,
                                          lastReadAt: String? = nil,
-                                         completion: @escaping (_ response: Error?) -> Void) -> URLSessionDataTaskProtocol? {
+                                         completion: @escaping (_ response: Error?) -> Void) -> URLSessionDataTaskProtocol?
+    {
         let router = NotificationRouter.markRepositoryNotificationsRead(configuration, owner, repository, lastReadAt)
         return router.load(session, completion: completion)
     }
-    
+
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     /**
      Marks All Repository Notifications As read
@@ -428,9 +462,9 @@ public extension Octokit {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func markRepositoryNotificationsRead(
         owner: String,
-                                             repository: String,
+        repository: String,
         lastReadAt: String? = nil
-    ) async throws -> Void {
+    ) async throws {
         let router = NotificationRouter.markRepositoryNotificationsRead(configuration, owner, repository, lastReadAt)
         return try await router.load(session)
     }

--- a/OctoKit/NotificationThread.swift
+++ b/OctoKit/NotificationThread.swift
@@ -7,7 +7,7 @@ import FoundationNetworking
 // MARK: - Model
 
 open class NotificationThread: Codable {
-    open internal(set) var id: String? = "-1"
+    open internal(set) var id: String = "-1"
     open var unread: Bool?
     open var reason: Reason?
     open var updatedAt: Date?
@@ -102,6 +102,23 @@ public extension Octokit {
             }
         }
     }
+    
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
+    /**
+     Fetches a user or organization
+     - parameter name: The name of the user or organization.
+     */
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func myNotifications(
+        all: Bool = false,
+        participating: Bool = false,
+        page: String = "1",
+        perPage: String = "100"
+    ) async throws -> [NotificationThread] {
+        let router = NotificationRouter.readNotifications(configuration, all, participating, page, perPage)
+        return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [NotificationThread].self)
+    }
+    #endif
 
     /**
      Marks All Notifications As read
@@ -116,6 +133,21 @@ public extension Octokit {
         let router = NotificationRouter.markNotificationsRead(configuration, lastReadAt, read)
         return router.load(session, completion: completion)
     }
+    
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
+    /**
+     Fetches a user or organization
+     - parameter name: The name of the user or organization.
+     */
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func markNotificationsRead(
+        lastReadAt: String = "last_read_at",
+        read: Bool = false
+    ) async throws -> Void {
+        let router = NotificationRouter.markNotificationsRead(configuration, lastReadAt, read)
+        return try await router.load(session)
+    }
+    #endif
 
     /**
      Marks All Notifications As read
@@ -136,6 +168,20 @@ public extension Octokit {
             }
         }
     }
+    
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
+    /**
+     Fetches a user or organization
+     - parameter name: The name of the user or organization.
+     */
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func getNotificationThread(
+        threadId: String
+    ) async throws -> NotificationThread {
+        let router = NotificationRouter.getNotificationThread(configuration, threadId)
+        return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: NotificationThread.self)
+    }
+    #endif
 
     /**
      Get a thread subscription for the authenticated user
@@ -156,6 +202,20 @@ public extension Octokit {
             }
         }
     }
+    
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
+    /**
+     Fetches a user or organization
+     - parameter name: The name of the user or organization.
+     */
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func getThreadSubscription(
+        threadId: String
+    ) async throws -> ThreadSubscription {
+        let router = NotificationRouter.getThreadSubscription(configuration, threadId)
+        return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: ThreadSubscription.self)
+    }
+    #endif
 
     /**
      Sets a thread subscription for the authenticated user
@@ -178,6 +238,21 @@ public extension Octokit {
             }
         }
     }
+    
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
+    /**
+     Fetches a user or organization
+     - parameter name: The name of the user or organization.
+     */
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func setThreadSubscription(
+        threadId: String,
+        ignored: Bool = false
+    ) async throws -> ThreadSubscription {
+        let router = NotificationRouter.setThreadSubscription(configuration, threadId, ignored)
+        return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: ThreadSubscription.self)
+    }
+    #endif
 
     /**
      Delete a thread subscription
@@ -189,6 +264,18 @@ public extension Octokit {
         let router = NotificationRouter.deleteThreadSubscription(configuration, threadId)
         return router.load(session, completion: completion)
     }
+    
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
+    /**
+     Fetches a user or organization
+     - parameter name: The name of the user or organization.
+     */
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func deleteThreadSubscription(threadId: String) async throws -> Void {
+        let router = NotificationRouter.deleteThreadSubscription(configuration, threadId)
+        return try await router.load(session)
+    }
+    #endif
 
     /**
      List all repository notifications for the current user, sorted by most recently updated.
@@ -223,6 +310,27 @@ public extension Octokit {
             }
         }
     }
+    
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
+    /**
+     Fetches a user or organization
+     - parameter name: The name of the user or organization.
+     */
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func listRepositoryNotifications(
+        owner: String,
+                                         repository: String,
+                                         all: Bool = false,
+                                         participating: Bool = false,
+                                         since: String? = nil,
+                                         before: String? = nil,
+                                         page: String = "1",
+        perPage: String = "100"
+    ) async throws -> [NotificationThread] {
+        let router = NotificationRouter.listRepositoryNotifications(configuration, owner, repository, all, participating, since, before, perPage, page)
+        return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [NotificationThread].self)
+    }
+    #endif
 
     /**
      Marks All Repository Notifications As read
@@ -239,6 +347,22 @@ public extension Octokit {
         let router = NotificationRouter.markRepositoryNotificationsRead(configuration, owner, repository, lastReadAt)
         return router.load(session, completion: completion)
     }
+    
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
+    /**
+     Fetches a user or organization
+     - parameter name: The name of the user or organization.
+     */
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func markRepositoryNotificationsRead(
+        owner: String,
+                                             repository: String,
+        lastReadAt: String? = nil
+    ) async throws -> Void {
+        let router = NotificationRouter.markRepositoryNotificationsRead(configuration, owner, repository, lastReadAt)
+        return try await router.load(session)
+    }
+    #endif
 }
 
 // MARK: - Router

--- a/OctoKit/NotificationThread.swift
+++ b/OctoKit/NotificationThread.swift
@@ -30,7 +30,6 @@ open class NotificationThread: Codable {
     }
 
     public class Subject: Codable {
-        open internal(set) var id: Int = -1
         open var title: String?
         open var url: String?
         open var latestCommentUrl: String?

--- a/Tests/OctoKitTests/NotificationTests.swift
+++ b/Tests/OctoKitTests/NotificationTests.swift
@@ -25,6 +25,22 @@ class NotificationTests: XCTestCase {
         XCTAssertNotNil(task)
         XCTAssertTrue(session.wasCalled)
     }
+    
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func testGetMyNotificationsAsync() async throws {
+        let config = TokenConfiguration("user:12345")
+        let headers = Helper.makeAuthHeader(username: "user", password: "12345")
+        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/notifications?all=false&page=1&participating=false&per_page=100",
+                                            expectedHTTPMethod: "GET",
+                                            expectedHTTPHeaders: headers,
+                                            jsonFile: "notification_threads",
+                                            statusCode: 200)
+        let notifications = try await Octokit(config, session: session).myNotifications(all: false, participating: false, page: "1", perPage: "100")
+        XCTAssertEqual(notifications.count, 1)
+        XCTAssertTrue(session.wasCalled)
+    }
+    #endif
 
     func testMarkNotifcationsRead() {
         let config = TokenConfiguration("user:12345")
@@ -40,6 +56,22 @@ class NotificationTests: XCTestCase {
         XCTAssertNotNil(task)
         XCTAssertTrue(session.wasCalled)
     }
+    
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func testMarkNotifcationsReadAsync() async throws {
+        let config = TokenConfiguration("user:12345")
+        let headers = Helper.makeAuthHeader(username: "user", password: "12345")
+        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/notifications?last_read_at=last_read_at&read=false",
+                                            expectedHTTPMethod: "PUT",
+                                            expectedHTTPHeaders: headers,
+                                            response: "",
+                                            statusCode: 200)
+        try await Octokit(config, session: session).markNotificationsRead()
+        XCTAssertTrue(session.wasCalled)
+    }
+    #endif
+    
 
     func testGetNotificationThread() {
         let config = TokenConfiguration("user:12345")
@@ -60,6 +92,22 @@ class NotificationTests: XCTestCase {
         XCTAssertNotNil(task)
         XCTAssertTrue(session.wasCalled)
     }
+    
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func testGetNotificationThreadAsync() async throws {
+        let config = TokenConfiguration("user:12345")
+        let headers = Helper.makeAuthHeader(username: "user", password: "12345")
+        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/notifications/threads/1",
+                                            expectedHTTPMethod: "GET",
+                                            expectedHTTPHeaders: headers,
+                                            jsonFile: "notification_thread",
+                                            statusCode: 200)
+        let notification = try await Octokit(config, session: session).getNotificationThread(threadId: "1")
+        XCTAssertEqual(notification.id, "1")
+        XCTAssertTrue(session.wasCalled)
+    }
+    #endif
 
     func testGetThreadSubscription() {
         let config = TokenConfiguration("user:12345")
@@ -80,6 +128,22 @@ class NotificationTests: XCTestCase {
         XCTAssertNotNil(task)
         XCTAssertTrue(session.wasCalled)
     }
+    
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func testGetThreadSubscriptionAsync() async throws {
+        let config = TokenConfiguration("user:12345")
+        let headers = Helper.makeAuthHeader(username: "user", password: "12345")
+        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/notifications/threads/1/subscription",
+                                            expectedHTTPMethod: "GET",
+                                            expectedHTTPHeaders: headers,
+                                            jsonFile: "notification_thread_subscription",
+                                            statusCode: 200)
+        let notification = try await Octokit(config, session: session).getThreadSubscription(threadId: "1")
+        XCTAssertEqual(notification.id, 1)
+        XCTAssertTrue(session.wasCalled)
+    }
+    #endif
 
     func testSetThreadSubscription() {
         let config = TokenConfiguration("user:12345")
@@ -100,6 +164,22 @@ class NotificationTests: XCTestCase {
         XCTAssertNotNil(task)
         XCTAssertTrue(session.wasCalled)
     }
+    
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func testSetThreadSubscriptionAsync() async throws {
+        let config = TokenConfiguration("user:12345")
+        let headers = Helper.makeAuthHeader(username: "user", password: "12345")
+        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/notifications/threads/1/subscription",
+                                            expectedHTTPMethod: "PUT",
+                                            expectedHTTPHeaders: headers,
+                                            jsonFile: "notification_thread_subscription",
+                                            statusCode: 200)
+        let notification = try await Octokit(config, session: session).setThreadSubscription(threadId: "1")
+        XCTAssertEqual(notification.id, 1)
+        XCTAssertTrue(session.wasCalled)
+    }
+    #endif
 
     func testDeleteThreadSubscription() {
         let config = TokenConfiguration("user:12345")
@@ -115,6 +195,21 @@ class NotificationTests: XCTestCase {
         XCTAssertNotNil(task)
         XCTAssertTrue(session.wasCalled)
     }
+    
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func testDeleteThreadSubscriptionAsync() async throws {
+        let config = TokenConfiguration("user:12345")
+        let headers = Helper.makeAuthHeader(username: "user", password: "12345")
+        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/notifications/threads/1/subscription",
+                                            expectedHTTPMethod: "DELETE",
+                                            expectedHTTPHeaders: headers,
+                                            response: "",
+                                            statusCode: 200)
+        try await Octokit(config, session: session).deleteThreadSubscription(threadId: "1")
+        XCTAssertTrue(session.wasCalled)
+    }
+    #endif
 
     func testListRepositoryNotifications() {
         let config = TokenConfiguration("user:12345")
@@ -136,6 +231,23 @@ class NotificationTests: XCTestCase {
         XCTAssertNotNil(task)
         XCTAssertTrue(session.wasCalled)
     }
+    
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func testListRepositoryNotificationsAsync() async throws {
+        let config = TokenConfiguration("user:12345")
+        let headers = Helper.makeAuthHeader(username: "user", password: "12345")
+        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/hello-world/notifications?all=false&page=1&participating=false&perPage=100",
+                                            expectedHTTPMethod: "GET",
+                                            expectedHTTPHeaders: headers,
+                                            jsonFile: "notification_threads",
+                                            statusCode: 200)
+        let notifications = try await Octokit(config, session: session).listRepositoryNotifications(owner: "octocat", repository: "hello-world")
+        XCTAssertEqual(notifications.count, 1)
+        XCTAssertEqual(notifications.first?.id, "1")
+        XCTAssertTrue(session.wasCalled)
+    }
+    #endif
 
     func testMarkRepositoryNofificationsRead() {
         let config = TokenConfiguration("user:12345")
@@ -151,4 +263,19 @@ class NotificationTests: XCTestCase {
         XCTAssertNotNil(task)
         XCTAssertTrue(session.wasCalled)
     }
+    
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func testMarkRepositoryNofificationsReadAsync() async throws {
+        let config = TokenConfiguration("user:12345")
+        let headers = Helper.makeAuthHeader(username: "user", password: "12345")
+        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/hello-world/notifications",
+                                            expectedHTTPMethod: "PUT",
+                                            expectedHTTPHeaders: headers,
+                                            response: "",
+                                            statusCode: 200)
+        try await Octokit(config, session: session).markRepositoryNotificationsRead(owner: "octocat", repository: "hello-world")
+        XCTAssertTrue(session.wasCalled)
+    }
+    #endif
 }

--- a/Tests/OctoKitTests/NotificationTests.swift
+++ b/Tests/OctoKitTests/NotificationTests.swift
@@ -25,7 +25,7 @@ class NotificationTests: XCTestCase {
         XCTAssertNotNil(task)
         XCTAssertTrue(session.wasCalled)
     }
-    
+
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func testGetMyNotificationsAsync() async throws {
@@ -56,7 +56,7 @@ class NotificationTests: XCTestCase {
         XCTAssertNotNil(task)
         XCTAssertTrue(session.wasCalled)
     }
-    
+
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func testMarkNotifcationsReadAsync() async throws {
@@ -71,7 +71,6 @@ class NotificationTests: XCTestCase {
         XCTAssertTrue(session.wasCalled)
     }
     #endif
-    
 
     func testGetNotificationThread() {
         let config = TokenConfiguration("user:12345")
@@ -92,7 +91,7 @@ class NotificationTests: XCTestCase {
         XCTAssertNotNil(task)
         XCTAssertTrue(session.wasCalled)
     }
-    
+
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func testGetNotificationThreadAsync() async throws {
@@ -128,7 +127,7 @@ class NotificationTests: XCTestCase {
         XCTAssertNotNil(task)
         XCTAssertTrue(session.wasCalled)
     }
-    
+
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func testGetThreadSubscriptionAsync() async throws {
@@ -164,7 +163,7 @@ class NotificationTests: XCTestCase {
         XCTAssertNotNil(task)
         XCTAssertTrue(session.wasCalled)
     }
-    
+
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func testSetThreadSubscriptionAsync() async throws {
@@ -195,7 +194,7 @@ class NotificationTests: XCTestCase {
         XCTAssertNotNil(task)
         XCTAssertTrue(session.wasCalled)
     }
-    
+
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func testDeleteThreadSubscriptionAsync() async throws {
@@ -231,7 +230,7 @@ class NotificationTests: XCTestCase {
         XCTAssertNotNil(task)
         XCTAssertTrue(session.wasCalled)
     }
-    
+
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func testListRepositoryNotificationsAsync() async throws {
@@ -263,7 +262,7 @@ class NotificationTests: XCTestCase {
         XCTAssertNotNil(task)
         XCTAssertTrue(session.wasCalled)
     }
-    
+
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func testMarkRepositoryNofificationsReadAsync() async throws {


### PR DESCRIPTION
- Added async-await support for all notification endpoints (and added tests)
- Added Constructors for `NotificationThread` and `Subject`
- added `markThreadasDone` endpoint support