### PR TITLE
Fix pull request comments page & per_page parameters

### DIFF
--- a/OctoKit/PullRequest.swift
+++ b/OctoKit/PullRequest.swift
@@ -799,10 +799,10 @@ enum PullRequestRouter: JSONPostRouter {
              let .readPullRequestRequestedReviewers(_, _, _, _, page, perPage):
             var parameters: [String: Any] = [:]
             if let perPage {
-                parameters["per_page"] = perPage
+                parameters["per_page"] = String(perPage)
             }
             if let page {
-                parameters["page"] = page
+                parameters["page"] = String(page)
             }
             return parameters
         case let .createPullRequestReviewComment(_, _, _, _, commitId, path, line, body):

--- a/Tests/OctoKitTests/PullRequestTests.swift
+++ b/Tests/OctoKitTests/PullRequestTests.swift
@@ -431,7 +431,7 @@ class PullRequestTests: XCTestCase {
     #endif
 
     func testReadPullRequestReviewComments() {
-        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octokat/Hello-World/pulls/1347/comments?",
+        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octokat/Hello-World/pulls/1347/comments?page=1&per_page=100",
                                             expectedHTTPMethod: "GET",
                                             jsonFile: "pull_request_comments",
                                             statusCode: 200)
@@ -455,7 +455,7 @@ class PullRequestTests: XCTestCase {
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func testReadPullRequestReviewCommentsAsync() async throws {
-        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octokat/Hello-World/pulls/1347/comments?",
+        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octokat/Hello-World/pulls/1347/comments?page=1&per_page=100",
                                             expectedHTTPMethod: "GET",
                                             jsonFile: "pull_request_comments",
                                             statusCode: 200)
@@ -563,7 +563,7 @@ class PullRequestTests: XCTestCase {
     #endif
 
     func testReadPullRequestRequestedReviewers() {
-        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octokat/Hello-World/pulls/1347/requested_reviewers?",
+        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octokat/Hello-World/pulls/1347/requested_reviewers?page=1&per_page=100",
                                             expectedHTTPMethod: "GET",
                                             jsonFile: "pull_request_requested_reviewers",
                                             statusCode: 200)
@@ -587,7 +587,7 @@ class PullRequestTests: XCTestCase {
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func testReadPullRequestRequestedReviewersAsync() async throws {
-        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octokat/Hello-World/pulls/1347/requested_reviewers?",
+        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octokat/Hello-World/pulls/1347/requested_reviewers?page=1&per_page=100",
                                             expectedHTTPMethod: "GET",
                                             jsonFile: "pull_request_requested_reviewers",
                                             statusCode: 200)


### PR DESCRIPTION
Since RequestKit doesn’t support Int as a query parameter value we need to convert the page and per_page parameters to String before adding them to the dictionary.