### PR TITLE
Adopt RequestKit 3.4.0: centralize JSONDecoder in TokenConfiguration

### DIFF
--- a/OctoKit/Configuration.swift
+++ b/OctoKit/Configuration.swift
@@ -26,6 +26,12 @@ public struct TokenConfiguration: Configuration {
         return previewCustomHeaders
     }
 
+    public var decoder: JSONDecoder {
+        let jsonDecoder = JSONDecoder()
+        jsonDecoder.dateDecodingStrategy = .formatted(Time.rfc3339DateFormatter)
+        return jsonDecoder
+    }
+
     public init(_ token: String? = nil, url: String = githubBaseURL, previewHeaders: [PreviewHeader] = []) {
         apiEndpoint = url
         accessToken = token?.data(using: .utf8)!.base64EncodedString()

--- a/OctoKit/Follow.swift
+++ b/OctoKit/Follow.swift
@@ -12,7 +12,7 @@ public extension Octokit {
     @discardableResult
     func myFollowers(completion: @escaping (_ response: Result<[User], Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = FollowRouter.readAuthenticatedFollowers(configuration)
-        return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [User].self) { users, error in
+        return router.load(session, decoder: configuration.decoder, expectedResultType: [User].self) { users, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -30,7 +30,7 @@ public extension Octokit {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func myFollowers() async throws -> [User] {
         let router = FollowRouter.readAuthenticatedFollowers(configuration)
-        return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [User].self)
+        return try await router.load(session, decoder: configuration.decoder, expectedResultType: [User].self)
     }
     #endif
 
@@ -42,7 +42,7 @@ public extension Octokit {
     @discardableResult
     func followers(name: String, completion: @escaping (_ response: Result<[User], Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = FollowRouter.readFollowers(name, configuration)
-        return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [User].self) { users, error in
+        return router.load(session, decoder: configuration.decoder, expectedResultType: [User].self) { users, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -61,7 +61,7 @@ public extension Octokit {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func followers(name: String) async throws -> [User] {
         let router = FollowRouter.readFollowers(name, configuration)
-        return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [User].self)
+        return try await router.load(session, decoder: configuration.decoder, expectedResultType: [User].self)
     }
     #endif
 
@@ -72,7 +72,7 @@ public extension Octokit {
     @discardableResult
     func myFollowing(completion: @escaping (_ response: Result<[User], Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = FollowRouter.readAuthenticatedFollowing(configuration)
-        return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [User].self) { users, error in
+        return router.load(session, decoder: configuration.decoder, expectedResultType: [User].self) { users, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -90,7 +90,7 @@ public extension Octokit {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func myFollowing() async throws -> [User] {
         let router = FollowRouter.readAuthenticatedFollowing(configuration)
-        return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [User].self)
+        return try await router.load(session, decoder: configuration.decoder, expectedResultType: [User].self)
     }
     #endif
 
@@ -102,7 +102,7 @@ public extension Octokit {
     @discardableResult
     func following(name: String, completion: @escaping (_ response: Result<[User], Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = FollowRouter.readFollowing(name, configuration)
-        return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [User].self) { users, error in
+        return router.load(session, decoder: configuration.decoder, expectedResultType: [User].self) { users, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -121,7 +121,7 @@ public extension Octokit {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func following(name: String) async throws -> [User] {
         let router = FollowRouter.readFollowing(name, configuration)
-        return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [User].self)
+        return try await router.load(session, decoder: configuration.decoder, expectedResultType: [User].self)
     }
     #endif
 }

--- a/OctoKit/Gist.swift
+++ b/OctoKit/Gist.swift
@@ -96,7 +96,7 @@ public extension Octokit {
                  perPage: String = "100",
                  completion: @escaping (_ response: Result<[Gist], Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = GistRouter.readAuthenticatedGists(configuration, page, perPage)
-        return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Gist].self) { gists, error in
+        return router.load(session, decoder: configuration.decoder, expectedResultType: [Gist].self) { gists, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -116,7 +116,7 @@ public extension Octokit {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func myGists(page: String = "1", perPage: String = "100") async throws -> [Gist] {
         let router = GistRouter.readAuthenticatedGists(configuration, page, perPage)
-        return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Gist].self)
+        return try await router.load(session, decoder: configuration.decoder, expectedResultType: [Gist].self)
     }
     #endif
 
@@ -131,7 +131,7 @@ public extension Octokit {
                         perPage: String = "100",
                         completion: @escaping (_ response: Result<[Gist], Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = GistRouter.readAuthenticatedStarredGists(configuration, page, perPage)
-        return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Gist].self) { gists, error in
+        return router.load(session, decoder: configuration.decoder, expectedResultType: [Gist].self) { gists, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -151,7 +151,7 @@ public extension Octokit {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func myStarredGists(page: String = "1", perPage: String = "100") async throws -> [Gist] {
         let router = GistRouter.readAuthenticatedStarredGists(configuration, page, perPage)
-        return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Gist].self)
+        return try await router.load(session, decoder: configuration.decoder, expectedResultType: [Gist].self)
     }
     #endif
 
@@ -168,7 +168,7 @@ public extension Octokit {
                perPage: String = "100",
                completion: @escaping (_ response: Result<[Gist], Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = GistRouter.readGists(configuration, owner, page, perPage)
-        return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Gist].self) { gists, error in
+        return router.load(session, decoder: configuration.decoder, expectedResultType: [Gist].self) { gists, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -189,7 +189,7 @@ public extension Octokit {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func gists(owner: String, page: String = "1", perPage: String = "100") async throws -> [Gist] {
         let router = GistRouter.readGists(configuration, owner, page, perPage)
-        return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Gist].self)
+        return try await router.load(session, decoder: configuration.decoder, expectedResultType: [Gist].self)
     }
     #endif
 
@@ -201,7 +201,7 @@ public extension Octokit {
     @discardableResult
     func gist(id: String, completion: @escaping (_ response: Result<Gist, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = GistRouter.readGist(configuration, id)
-        return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: Gist.self) { gist, error in
+        return router.load(session, decoder: configuration.decoder, expectedResultType: Gist.self) { gist, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -220,7 +220,7 @@ public extension Octokit {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func gist(id: String) async throws -> Gist {
         let router = GistRouter.readGist(configuration, id)
-        return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: Gist.self)
+        return try await router.load(session, decoder: configuration.decoder, expectedResultType: Gist.self)
     }
     #endif
 
@@ -239,9 +239,7 @@ public extension Octokit {
                       publicAccess: Bool,
                       completion: @escaping (_ response: Result<Gist, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = GistRouter.postGistFile(configuration, description, filename, fileContent, publicAccess)
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .formatted(Time.rfc3339DateFormatter)
-        return router.post(session, decoder: decoder, expectedResultType: Gist.self) { gist, error in
+        return router.post(session, decoder: configuration.decoder, expectedResultType: Gist.self) { gist, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -263,9 +261,7 @@ public extension Octokit {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func postGistFile(description: String, filename: String, fileContent: String, publicAccess: Bool) async throws -> Gist {
         let router = GistRouter.postGistFile(configuration, description, filename, fileContent, publicAccess)
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .formatted(Time.rfc3339DateFormatter)
-        return try await router.post(session, decoder: decoder, expectedResultType: Gist.self)
+        return try await router.post(session, decoder: configuration.decoder, expectedResultType: Gist.self)
     }
     #endif
 
@@ -284,9 +280,7 @@ public extension Octokit {
                        fileContent: String,
                        completion: @escaping (_ response: Result<Gist, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = GistRouter.patchGistFile(configuration, id, description, filename, fileContent)
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .formatted(Time.rfc3339DateFormatter)
-        return router.post(session, decoder: decoder, expectedResultType: Gist.self) { gist, error in
+        return router.post(session, decoder: configuration.decoder, expectedResultType: Gist.self) { gist, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -308,9 +302,7 @@ public extension Octokit {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func patchGistFile(id: String, description: String, filename: String, fileContent: String) async throws -> Gist {
         let router = GistRouter.patchGistFile(configuration, id, description, filename, fileContent)
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .formatted(Time.rfc3339DateFormatter)
-        return try await router.post(session, decoder: decoder, expectedResultType: Gist.self)
+        return try await router.post(session, decoder: configuration.decoder, expectedResultType: Gist.self)
     }
     #endif
 }

--- a/OctoKit/Issue.swift
+++ b/OctoKit/Issue.swift
@@ -140,7 +140,7 @@ public extension Octokit {
                   perPage: String = "100",
                   completion: @escaping (_ response: Result<[Issue], Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = IssueRouter.readAuthenticatedIssues(configuration, page, perPage, state)
-        return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Issue].self) { issues, error in
+        return router.load(session, decoder: configuration.decoder, expectedResultType: [Issue].self) { issues, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -164,7 +164,7 @@ public extension Octokit {
                   page: String = "1",
                   perPage: String = "100") async throws -> [Issue] {
         let router = IssueRouter.readAuthenticatedIssues(configuration, page, perPage, state)
-        return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Issue].self)
+        return try await router.load(session, decoder: configuration.decoder, expectedResultType: [Issue].self)
     }
     #endif
 
@@ -181,7 +181,7 @@ public extension Octokit {
                number: Int,
                completion: @escaping (_ response: Result<Issue, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = IssueRouter.readIssue(configuration, owner, repository, number)
-        return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: Issue.self) { issue, error in
+        return router.load(session, decoder: configuration.decoder, expectedResultType: Issue.self) { issue, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -203,7 +203,7 @@ public extension Octokit {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func issue(owner: String, repository: String, number: Int) async throws -> Issue {
         let router = IssueRouter.readIssue(configuration, owner, repository, number)
-        return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: Issue.self)
+        return try await router.load(session, decoder: configuration.decoder, expectedResultType: Issue.self)
     }
     #endif
 
@@ -224,7 +224,7 @@ public extension Octokit {
                 perPage: String = "100",
                 completion: @escaping (_ response: Result<[Issue], Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = IssueRouter.readIssues(configuration, owner, repository, page, perPage, state)
-        return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Issue].self) { issues, error in
+        return router.load(session, decoder: configuration.decoder, expectedResultType: [Issue].self) { issues, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -252,7 +252,7 @@ public extension Octokit {
                 page: String = "1",
                 perPage: String = "100") async throws -> [Issue] {
         let router = IssueRouter.readIssues(configuration, owner, repository, page, perPage, state)
-        return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Issue].self)
+        return try await router.load(session, decoder: configuration.decoder, expectedResultType: [Issue].self)
     }
     #endif
 
@@ -275,9 +275,7 @@ public extension Octokit {
                    labels: [String] = [],
                    completion: @escaping (_ response: Result<Issue, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = IssueRouter.postIssue(configuration, owner, repository, title, body, assignee, labels)
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .formatted(Time.rfc3339DateFormatter)
-        return router.post(session, decoder: decoder, expectedResultType: Issue.self) { issue, error in
+        return router.post(session, decoder: configuration.decoder, expectedResultType: Issue.self) { issue, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -306,9 +304,7 @@ public extension Octokit {
                    assignee: String? = nil,
                    labels: [String] = []) async throws -> Issue {
         let router = IssueRouter.postIssue(configuration, owner, repository, title, body, assignee, labels)
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .formatted(Time.rfc3339DateFormatter)
-        return try await router.post(session, decoder: decoder, expectedResultType: Issue.self)
+        return try await router.post(session, decoder: configuration.decoder, expectedResultType: Issue.self)
     }
     #endif
 
@@ -333,9 +329,7 @@ public extension Octokit {
                     state: Openness? = nil,
                     completion: @escaping (_ response: Result<Issue, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = IssueRouter.patchIssue(configuration, owner, repository, number, title, body, assignee, state)
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .formatted(Time.rfc3339DateFormatter)
-        return router.post(session, decoder: decoder, expectedResultType: Issue.self) { issue, error in
+        return router.post(session, decoder: configuration.decoder, expectedResultType: Issue.self) { issue, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -366,9 +360,7 @@ public extension Octokit {
                     assignee: String? = nil,
                     state: Openness? = nil) async throws -> Issue {
         let router = IssueRouter.patchIssue(configuration, owner, repository, number, title, body, assignee, state)
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .formatted(Time.rfc3339DateFormatter)
-        return try await router.post(session, decoder: decoder, expectedResultType: Issue.self)
+        return try await router.post(session, decoder: configuration.decoder, expectedResultType: Issue.self)
     }
     #endif
 
@@ -386,9 +378,7 @@ public extension Octokit {
                       body: String,
                       completion: @escaping (_ response: Result<Issue.Comment, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = IssueRouter.commentIssue(configuration, owner, repository, number, body)
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .formatted(Time.rfc3339DateFormatter)
-        return router.post(session, decoder: decoder, expectedResultType: Issue.Comment.self) { issue, error in
+        return router.post(session, decoder: configuration.decoder, expectedResultType: Issue.Comment.self) { issue, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -410,9 +400,7 @@ public extension Octokit {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func commentIssue(owner: String, repository: String, number: Int, body: String) async throws -> Issue.Comment {
         let router = IssueRouter.commentIssue(configuration, owner, repository, number, body)
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .formatted(Time.rfc3339DateFormatter)
-        return try await router.post(session, decoder: decoder, expectedResultType: Issue.Comment.self)
+        return try await router.post(session, decoder: configuration.decoder, expectedResultType: Issue.Comment.self)
     }
     #endif
 
@@ -432,7 +420,7 @@ public extension Octokit {
                        perPage: String = "100",
                        completion: @escaping (_ response: Result<[Issue.Comment], Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = IssueRouter.readIssueComments(configuration, owner, repository, number, page, perPage)
-        return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Issue.Comment].self) { comments, error in
+        return router.load(session, decoder: configuration.decoder, expectedResultType: [Issue.Comment].self) { comments, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -459,7 +447,7 @@ public extension Octokit {
                        page: String = "1",
                        perPage: String = "100") async throws -> [Issue.Comment] {
         let router = IssueRouter.readIssueComments(configuration, owner, repository, number, page, perPage)
-        return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Issue.Comment].self)
+        return try await router.load(session, decoder: configuration.decoder, expectedResultType: [Issue.Comment].self)
     }
     #endif
 
@@ -477,9 +465,7 @@ public extension Octokit {
                            body: String,
                            completion: @escaping (_ response: Result<Issue.Comment, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = IssueRouter.patchIssueComment(configuration, owner, repository, number, body)
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .formatted(Time.rfc3339DateFormatter)
-        return router.post(session, decoder: decoder, expectedResultType: Issue.Comment.self) { issue, error in
+        return router.post(session, decoder: configuration.decoder, expectedResultType: Issue.Comment.self) { issue, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -501,9 +487,7 @@ public extension Octokit {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func patchIssueComment(owner: String, repository: String, number: Int, body: String) async throws -> Issue.Comment {
         let router = IssueRouter.patchIssueComment(configuration, owner, repository, number, body)
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .formatted(Time.rfc3339DateFormatter)
-        return try await router.post(session, decoder: decoder, expectedResultType: Issue.Comment.self)
+        return try await router.post(session, decoder: configuration.decoder, expectedResultType: Issue.Comment.self)
     }
     #endif
 }

--- a/OctoKit/Label.swift
+++ b/OctoKit/Label.swift
@@ -34,7 +34,7 @@ public extension Octokit {
                name: String,
                completion: @escaping (_ response: Result<Label, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = LabelRouter.readLabel(configuration, owner, repository, name)
-        return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: Label.self) { label, error in
+        return router.load(session, decoder: configuration.decoder, expectedResultType: Label.self) { label, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -55,7 +55,7 @@ public extension Octokit {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func label(owner: String, repository: String, name: String) async throws -> Label {
         let router = LabelRouter.readLabel(configuration, owner, repository, name)
-        return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: Label.self)
+        return try await router.load(session, decoder: configuration.decoder, expectedResultType: Label.self)
     }
     #endif
 
@@ -74,7 +74,7 @@ public extension Octokit {
                 perPage: String = "100",
                 completion: @escaping (_ response: Result<[Label], Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = LabelRouter.readLabels(configuration, owner, repository, page, perPage)
-        return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Label].self) { labels, error in
+        return router.load(session, decoder: configuration.decoder, expectedResultType: [Label].self) { labels, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -96,7 +96,7 @@ public extension Octokit {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func labels(owner: String, repository: String, page: String = "1", perPage: String = "100") async throws -> [Label] {
         let router = LabelRouter.readLabels(configuration, owner, repository, page, perPage)
-        return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Label].self)
+        return try await router.load(session, decoder: configuration.decoder, expectedResultType: [Label].self)
     }
     #endif
 
@@ -115,7 +115,7 @@ public extension Octokit {
                    color: String,
                    completion: @escaping (_ response: Result<Label, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = LabelRouter.createLabel(configuration, owner, repository, name, color)
-        return router.post(session, expectedResultType: Label.self) { label, error in
+        return router.post(session, decoder: configuration.decoder, expectedResultType: Label.self) { label, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -137,7 +137,7 @@ public extension Octokit {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func postLabel(owner: String, repository: String, name: String, color: String) async throws -> Label {
         let router = LabelRouter.createLabel(configuration, owner, repository, name, color)
-        return try await router.post(session, expectedResultType: Label.self)
+        return try await router.post(session, decoder: configuration.decoder, expectedResultType: Label.self)
     }
     #endif
 }

--- a/OctoKit/Milestone.swift
+++ b/OctoKit/Milestone.swift
@@ -91,9 +91,7 @@ public extension Octokit {
                          dueDate: Date? = nil,
                          completion: @escaping (_ response: Result<Milestone, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = MilestoneRouter.createMilestone(configuration, owner, repo, title, state, description, dueDate)
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .formatted(Time.rfc3339DateFormatter)
-        return router.post(session, decoder: decoder, expectedResultType: Milestone.self) { milestone, error in
+        return router.post(session, decoder: configuration.decoder, expectedResultType: Milestone.self) { milestone, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -123,11 +121,7 @@ public extension Octokit {
                          description: String? = nil,
                          dueDate: Date? = nil) async throws -> Milestone {
         let router = MilestoneRouter.createMilestone(configuration, owner, repo, title, state, description, dueDate)
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .formatted(Time.rfc3339DateFormatter)
-        return try await router.post(session,
-                                     decoder: decoder,
-                                     expectedResultType: Milestone.self)
+        return try await router.post(session, decoder: configuration.decoder, expectedResultType: Milestone.self)
     }
     #endif
 
@@ -143,9 +137,7 @@ public extension Octokit {
                    number: Int,
                    completion: @escaping (_ response: Result<Milestone, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = MilestoneRouter.readMilestone(configuration, owner, repo, number)
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .formatted(Time.rfc3339DateFormatter)
-        return router.post(session, decoder: decoder, expectedResultType: Milestone.self) { milestone, error in
+        return router.post(session, decoder: configuration.decoder, expectedResultType: Milestone.self) { milestone, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -168,9 +160,7 @@ public extension Octokit {
                    repo: String,
                    number: Int) async throws -> Milestone {
         let router = MilestoneRouter.readMilestone(configuration, owner, repo, number)
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .formatted(Time.rfc3339DateFormatter)
-        return try await router.post(session, decoder: decoder, expectedResultType: Milestone.self)
+        return try await router.post(session, decoder: configuration.decoder, expectedResultType: Milestone.self)
     }
     #endif
 
@@ -194,9 +184,7 @@ public extension Octokit {
                     perPage: Int? = nil,
                     completion: @escaping (_ response: Result<[Milestone], Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = MilestoneRouter.readMilestones(configuration, owner, repo, state, sort, direction, perPage, page)
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .formatted(Time.rfc3339DateFormatter)
-        return router.load(session, decoder: decoder, expectedResultType: [Milestone].self) { milestones, error in
+        return router.load(session, decoder: configuration.decoder, expectedResultType: [Milestone].self) { milestones, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -227,9 +215,7 @@ public extension Octokit {
                     page: Int? = nil,
                     perPage: Int? = nil) async throws -> [Milestone] {
         let router = MilestoneRouter.readMilestones(configuration, owner, repo, state, sort, direction, perPage, page)
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .formatted(Time.rfc3339DateFormatter)
-        return try await router.load(session, decoder: decoder, expectedResultType: [Milestone].self)
+        return try await router.load(session, decoder: configuration.decoder, expectedResultType: [Milestone].self)
     }
     #endif
 
@@ -254,9 +240,7 @@ public extension Octokit {
                          dueDate: Date? = nil,
                          completion: @escaping (_ response: Result<Milestone, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = MilestoneRouter.updateMilestone(configuration, owner, repo, number, title, state, description, dueDate)
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .formatted(Time.rfc3339DateFormatter)
-        return router.post(session, decoder: decoder, expectedResultType: Milestone.self) { milestone, error in
+        return router.post(session, decoder: configuration.decoder, expectedResultType: Milestone.self) { milestone, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -287,9 +271,7 @@ public extension Octokit {
                          description: String? = nil,
                          dueDate: Date? = nil) async throws -> Milestone {
         let router = MilestoneRouter.updateMilestone(configuration, owner, repo, number, title, state, description, dueDate)
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .formatted(Time.rfc3339DateFormatter)
-        return try await router.post(session, decoder: decoder, expectedResultType: Milestone.self)
+        return try await router.post(session, decoder: configuration.decoder, expectedResultType: Milestone.self)
     }
     #endif
 

--- a/OctoKit/NotificationThread.swift
+++ b/OctoKit/NotificationThread.swift
@@ -122,7 +122,7 @@ public extension Octokit {
                          perPage: String = "100",
                          completion: @escaping (_ response: Result<[NotificationThread], Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = NotificationRouter.readNotifications(configuration, all, participating, page, perPage)
-        return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [NotificationThread].self) { notifications, error in
+        return router.load(session, decoder: configuration.decoder, expectedResultType: [NotificationThread].self) { notifications, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -147,7 +147,7 @@ public extension Octokit {
                          page: String = "1",
                          perPage: String = "100") async throws -> [NotificationThread] {
         let router = NotificationRouter.readNotifications(configuration, all, participating, page, perPage)
-        return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [NotificationThread].self)
+        return try await router.load(session, decoder: configuration.decoder, expectedResultType: [NotificationThread].self)
     }
     #endif
 
@@ -236,7 +236,7 @@ public extension Octokit {
     func getNotificationThread(threadId: String,
                                completion: @escaping (_ response: Result<NotificationThread, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = NotificationRouter.getNotificationThread(configuration, threadId)
-        return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: NotificationThread.self) { notification, error in
+        return router.load(session, decoder: configuration.decoder, expectedResultType: NotificationThread.self) { notification, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -255,7 +255,7 @@ public extension Octokit {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func getNotificationThread(threadId: String) async throws -> NotificationThread {
         let router = NotificationRouter.getNotificationThread(configuration, threadId)
-        return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: NotificationThread.self)
+        return try await router.load(session, decoder: configuration.decoder, expectedResultType: NotificationThread.self)
     }
     #endif
 
@@ -268,7 +268,7 @@ public extension Octokit {
     func getThreadSubscription(threadId: String,
                                completion: @escaping (_ response: Result<ThreadSubscription, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = NotificationRouter.getThreadSubscription(configuration, threadId)
-        return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: ThreadSubscription.self) { thread, error in
+        return router.load(session, decoder: configuration.decoder, expectedResultType: ThreadSubscription.self) { thread, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -287,7 +287,7 @@ public extension Octokit {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func getThreadSubscription(threadId: String) async throws -> ThreadSubscription {
         let router = NotificationRouter.getThreadSubscription(configuration, threadId)
-        return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: ThreadSubscription.self)
+        return try await router.load(session, decoder: configuration.decoder, expectedResultType: ThreadSubscription.self)
     }
     #endif
 
@@ -302,7 +302,7 @@ public extension Octokit {
                                ignored: Bool = false,
                                completion: @escaping (_ response: Result<ThreadSubscription, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = NotificationRouter.setThreadSubscription(configuration, threadId, ignored)
-        return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: ThreadSubscription.self) { thread, error in
+        return router.load(session, decoder: configuration.decoder, expectedResultType: ThreadSubscription.self) { thread, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -323,7 +323,7 @@ public extension Octokit {
     func setThreadSubscription(threadId: String,
                                ignored: Bool = false) async throws -> ThreadSubscription {
         let router = NotificationRouter.setThreadSubscription(configuration, threadId, ignored)
-        return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: ThreadSubscription.self)
+        return try await router.load(session, decoder: configuration.decoder, expectedResultType: ThreadSubscription.self)
     }
     #endif
 
@@ -373,7 +373,7 @@ public extension Octokit {
                                      perPage: String = "100",
                                      completion: @escaping (_ response: Result<[NotificationThread], Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = NotificationRouter.listRepositoryNotifications(configuration, owner, repository, all, participating, since, before, perPage, page)
-        return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [NotificationThread].self) { notifications, error in
+        return router.load(session, decoder: configuration.decoder, expectedResultType: [NotificationThread].self) { notifications, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -406,7 +406,7 @@ public extension Octokit {
                                      page: String = "1",
                                      perPage: String = "100") async throws -> [NotificationThread] {
         let router = NotificationRouter.listRepositoryNotifications(configuration, owner, repository, all, participating, since, before, perPage, page)
-        return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [NotificationThread].self)
+        return try await router.load(session, decoder: configuration.decoder, expectedResultType: [NotificationThread].self)
     }
     #endif
 

--- a/OctoKit/PullRequest.swift
+++ b/OctoKit/PullRequest.swift
@@ -260,9 +260,7 @@ public extension Octokit {
                            draft: Bool? = nil,
                            completion: @escaping (_ response: Result<PullRequest, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = PullRequestRouter.createPullRequest(configuration, owner, repo, title, head, headRepo, base, body, maintainerCanModify, draft)
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .formatted(Time.rfc3339DateFormatter)
-        return router.post(session, decoder: decoder, expectedResultType: PullRequest.self) { pullRequest, error in
+        return router.post(session, decoder: configuration.decoder, expectedResultType: PullRequest.self) { pullRequest, error in
             if let error = error {
                 completion(.failure(error))
             } else if let pullRequest {
@@ -296,9 +294,7 @@ public extension Octokit {
                            maintainerCanModify: Bool? = nil,
                            draft: Bool? = nil) async throws -> PullRequest {
         let router = PullRequestRouter.createPullRequest(configuration, owner, repo, title, head, headRepo, base, body, maintainerCanModify, draft)
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .formatted(Time.rfc3339DateFormatter)
-        return try await router.post(session, decoder: decoder, expectedResultType: PullRequest.self)
+        return try await router.post(session, decoder: configuration.decoder, expectedResultType: PullRequest.self)
     }
     #endif
 
@@ -315,7 +311,7 @@ public extension Octokit {
                      number: Int,
                      completion: @escaping (_ response: Result<PullRequest, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = PullRequestRouter.readPullRequest(configuration, owner, repository, "\(number)")
-        return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: PullRequest.self) { pullRequest, error in
+        return router.load(session, decoder: configuration.decoder, expectedResultType: PullRequest.self) { pullRequest, error in
             if let error = error {
                 completion(.failure(error))
             } else if let pullRequest {
@@ -336,7 +332,7 @@ public extension Octokit {
                      repository: String,
                      number: Int) async throws -> PullRequest {
         let router = PullRequestRouter.readPullRequest(configuration, owner, repository, "\(number)")
-        return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: PullRequest.self)
+        return try await router.load(session, decoder: configuration.decoder, expectedResultType: PullRequest.self)
     }
     #endif
 
@@ -364,7 +360,7 @@ public extension Octokit {
                       perPage: String? = nil,
                       completion: @escaping (_ response: Result<[PullRequest], Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = PullRequestRouter.readPullRequests(configuration, owner, repository, base, head, state, sort, direction, page, perPage)
-        return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [PullRequest].self) { pullRequests, error in
+        return router.load(session, decoder: configuration.decoder, expectedResultType: [PullRequest].self) { pullRequests, error in
             if let error = error {
                 completion(.failure(error))
             } else if let pullRequests {
@@ -394,7 +390,7 @@ public extension Octokit {
                       perPage: String? = nil,
                       direction: SortDirection = .desc) async throws -> [PullRequest] {
         let router = PullRequestRouter.readPullRequests(configuration, owner, repository, base, head, state, sort, direction, page, perPage)
-        return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [PullRequest].self)
+        return try await router.load(session, decoder: configuration.decoder, expectedResultType: [PullRequest].self)
     }
     #endif
 
@@ -422,9 +418,7 @@ public extension Octokit {
                           completion: @escaping (_ response: Result<PullRequest, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         guard state != .all else { fatalError("Openess.all is not supported as a setting") }
         let router = PullRequestRouter.patchPullRequest(configuration, owner, repository, "\(number)", title, body, state, base, nil)
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .formatted(Time.rfc3339DateFormatter)
-        return router.post(session, decoder: decoder, expectedResultType: PullRequest.self) { pullRequest, error in
+        return router.post(session, decoder: configuration.decoder, expectedResultType: PullRequest.self) { pullRequest, error in
             if let error = error {
                 completion(.failure(error))
             } else if let pullRequest {
@@ -456,9 +450,7 @@ public extension Octokit {
                           mantainerCanModify _: Bool?) async throws -> PullRequest {
         guard state != .all else { fatalError("Openess.all is not supported as a setting") }
         let router = PullRequestRouter.patchPullRequest(configuration, owner, repository, "\(number)", title, body, state, base, nil)
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .formatted(Time.rfc3339DateFormatter)
-        return try await router.post(session, decoder: decoder, expectedResultType: PullRequest.self)
+        return try await router.post(session, decoder: configuration.decoder, expectedResultType: PullRequest.self)
     }
     #endif
 
@@ -469,7 +461,7 @@ public extension Octokit {
                                page: Int? = nil,
                                completion: @escaping (_ response: Result<[PullRequest.File], Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = PullRequestRouter.listPullRequestsFiles(configuration, owner, repository, number, perPage, page)
-        return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [PullRequest.File].self) { files, error in
+        return router.load(session, decoder: configuration.decoder, expectedResultType: [PullRequest.File].self) { files, error in
             if let error = error {
                 completion(.failure(error))
             } else if let files {
@@ -486,7 +478,7 @@ public extension Octokit {
                                perPage: Int? = nil,
                                page: Int? = nil) async throws -> [PullRequest.File] {
         let router = PullRequestRouter.listPullRequestsFiles(configuration, owner, repository, number, perPage, page)
-        return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [PullRequest.File].self)
+        return try await router.load(session, decoder: configuration.decoder, expectedResultType: [PullRequest.File].self)
     }
     #endif
 
@@ -506,7 +498,7 @@ public extension Octokit {
                                        perPage: Int = 100,
                                        completion: @escaping (_ response: Result<[PullRequest.Comment], Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = PullRequestRouter.readPullRequestReviewComments(configuration, owner, repository, number, page, perPage)
-        return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [PullRequest.Comment].self) { comments, error in
+        return router.load(session, decoder: configuration.decoder, expectedResultType: [PullRequest.Comment].self) { comments, error in
             if let error = error {
                 completion(.failure(error))
             } else if let comments {
@@ -530,7 +522,7 @@ public extension Octokit {
                                        page: Int = 1,
                                        perPage: Int = 100) async throws -> [PullRequest.Comment] {
         let router = PullRequestRouter.readPullRequestReviewComments(configuration, owner, repository, number, page, perPage)
-        return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [PullRequest.Comment].self)
+        return try await router.load(session, decoder: configuration.decoder, expectedResultType: [PullRequest.Comment].self)
     }
     #endif
 
@@ -554,9 +546,7 @@ public extension Octokit {
                                         body: String,
                                         completion: @escaping (_ response: Result<PullRequest.Comment, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = PullRequestRouter.createPullRequestReviewComment(configuration, owner, repository, number, commitId, path, line, body)
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .formatted(Time.rfc3339DateFormatter)
-        return router.post(session, decoder: decoder, expectedResultType: PullRequest.Comment.self) { issue, error in
+        return router.post(session, decoder: configuration.decoder, expectedResultType: PullRequest.Comment.self) { issue, error in
             if let error = error {
                 completion(.failure(error))
             } else if let issue {
@@ -584,9 +574,7 @@ public extension Octokit {
                                         line: Int,
                                         body: String) async throws -> PullRequest.Comment {
         let router = PullRequestRouter.createPullRequestReviewComment(configuration, owner, repository, number, commitId, path, line, body)
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .formatted(Time.rfc3339DateFormatter)
-        return try await router.post(session, decoder: decoder, expectedResultType: PullRequest.Comment.self)
+        return try await router.post(session, decoder: configuration.decoder, expectedResultType: PullRequest.Comment.self)
     }
     #endif
 
@@ -645,7 +633,7 @@ public extension Octokit {
                                            perPage: Int = 100,
                                            completion: @escaping (_ response: Result<PullRequest.RequestedReviewers, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = PullRequestRouter.readPullRequestRequestedReviewers(configuration, owner, repository, number, page, perPage)
-        return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: PullRequest.RequestedReviewers.self) { requestedReviewers, error in
+        return router.load(session, decoder: configuration.decoder, expectedResultType: PullRequest.RequestedReviewers.self) { requestedReviewers, error in
             if let error = error {
                 completion(.failure(error))
             } else if let requestedReviewers {
@@ -669,7 +657,7 @@ public extension Octokit {
                                            page: Int = 1,
                                            perPage: Int = 100) async throws -> PullRequest.RequestedReviewers {
         let router = PullRequestRouter.readPullRequestRequestedReviewers(configuration, owner, repository, number, page, perPage)
-        return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: PullRequest.RequestedReviewers.self)
+        return try await router.load(session, decoder: configuration.decoder, expectedResultType: PullRequest.RequestedReviewers.self)
     }
     #endif
 }

--- a/OctoKit/Releases.swift
+++ b/OctoKit/Releases.swift
@@ -96,7 +96,7 @@ public extension Octokit {
                       perPage: Int = 30,
                       completion: @escaping (_ response: Result<[Release], Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = ReleaseRouter.listReleases(configuration, owner, repository, perPage)
-        return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Release].self) { releases, error in
+        return router.load(session, decoder: configuration.decoder, expectedResultType: [Release].self) { releases, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -117,9 +117,7 @@ public extension Octokit {
                  tag: String,
                  completion: @escaping (_ response: Result<Release, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = ReleaseRouter.getReleaseByTag(configuration, owner, repository, tag)
-        return router.load(session,
-                           dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter),
-                           expectedResultType: Release.self) { release, error in
+        return router.load(session, decoder: configuration.decoder, expectedResultType: Release.self) { release, error in
             if let error = error {
                 completion(.failure(error))
             } else if let release = release {
@@ -137,7 +135,7 @@ public extension Octokit {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func listReleases(owner: String, repository: String, perPage: Int = 30) async throws -> [Release] {
         let router = ReleaseRouter.listReleases(configuration, owner, repository, perPage)
-        return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Release].self)
+        return try await router.load(session, decoder: configuration.decoder, expectedResultType: [Release].self)
     }
 
     /// Fetches the latest release.
@@ -147,7 +145,7 @@ public extension Octokit {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func getLatestRelease(owner: String, repository: String) async throws -> Release {
         let router = ReleaseRouter.getLatestRelease(configuration, owner, repository)
-        return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: Release.self)
+        return try await router.load(session, decoder: configuration.decoder, expectedResultType: Release.self)
     }
     #endif
 
@@ -175,10 +173,7 @@ public extension Octokit {
                      generateNotes: Bool = false,
                      completion: @escaping (_ response: Result<Release, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = ReleaseRouter.postRelease(configuration, owner, repository, tagName, targetCommitish, name, body, prerelease, draft, generateNotes)
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .formatted(Time.rfc3339DateFormatter)
-
-        return router.post(session, decoder: decoder, expectedResultType: Release.self) { issue, error in
+        return router.post(session, decoder: configuration.decoder, expectedResultType: Release.self) { issue, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -227,9 +222,7 @@ public extension Octokit {
                      draft: Bool = false,
                      generateNotes: Bool = false) async throws -> Release {
         let router = ReleaseRouter.postRelease(configuration, owner, repository, tagName, targetCommitish, name, body, prerelease, draft, generateNotes)
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .formatted(Time.rfc3339DateFormatter)
-        return try await router.post(session, decoder: decoder, expectedResultType: Release.self)
+        return try await router.post(session, decoder: configuration.decoder, expectedResultType: Release.self)
     }
     #endif
 }

--- a/OctoKit/Repositories.swift
+++ b/OctoKit/Repositories.swift
@@ -237,7 +237,7 @@ public extension Octokit {
         let router = (owner != nil)
             ? RepositoryRouter.readRepositories(configuration, owner!, page, perPage)
             : RepositoryRouter.readAuthenticatedRepositories(configuration, page, perPage)
-        return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Repository].self) { repos, error in
+        return router.load(session, decoder: configuration.decoder, expectedResultType: [Repository].self) { repos, error in
             if let error = error {
                 completion(.failure(error))
             }
@@ -260,7 +260,7 @@ public extension Octokit {
         let router = (owner != nil)
             ? RepositoryRouter.readRepositories(configuration, owner!, page, perPage)
             : RepositoryRouter.readAuthenticatedRepositories(configuration, page, perPage)
-        return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Repository].self)
+        return try await router.load(session, decoder: configuration.decoder, expectedResultType: [Repository].self)
     }
     #endif
 
@@ -275,7 +275,7 @@ public extension Octokit {
                     name: String,
                     completion: @escaping (_ response: Result<Repository, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = RepositoryRouter.readRepository(configuration, owner, name)
-        return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: Repository.self) { repo, error in
+        return router.load(session, decoder: configuration.decoder, expectedResultType: Repository.self) { repo, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -295,7 +295,7 @@ public extension Octokit {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func repository(owner: String, name: String) async throws -> Repository {
         let router = RepositoryRouter.readRepository(configuration, owner, name)
-        return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: Repository.self)
+        return try await router.load(session, decoder: configuration.decoder, expectedResultType: Repository.self)
     }
     #endif
 
@@ -308,7 +308,7 @@ public extension Octokit {
     @discardableResult
     func repositoryTopics(owner: String, name: String, completion: @escaping (_ response: Result<Topics, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = RepositoryRouter.getRepositoryTopics(configuration, owner: owner, name: name)
-        return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: Topics.self) { contentResponse, error in
+        return router.load(session, decoder: configuration.decoder, expectedResultType: Topics.self) { contentResponse, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -329,7 +329,7 @@ public extension Octokit {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func repositoryTopics(owner: String, name: String) async throws -> Topics {
         let router = RepositoryRouter.getRepositoryTopics(configuration, owner: owner, name: name)
-        return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: Topics.self)
+        return try await router.load(session, decoder: configuration.decoder, expectedResultType: Topics.self)
     }
     #endif
 
@@ -349,7 +349,7 @@ public extension Octokit {
                            ref: String?,
                            completion: @escaping (_ response: Result<ContentResponse, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = RepositoryRouter.getRepositoryContent(configuration, owner, name, path, ref)
-        return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: ContentResponse.self) { contentResponse, error in
+        return router.load(session, decoder: configuration.decoder, expectedResultType: ContentResponse.self) { contentResponse, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -372,7 +372,7 @@ public extension Octokit {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func repositoryContent(owner: String, name: String, path: String?, ref: String? = nil) async throws -> ContentResponse {
         let router = RepositoryRouter.getRepositoryContent(configuration, owner, name, path, ref)
-        return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: ContentResponse.self)
+        return try await router.load(session, decoder: configuration.decoder, expectedResultType: ContentResponse.self)
     }
     #endif
 }

--- a/OctoKit/Review.swift
+++ b/OctoKit/Review.swift
@@ -86,7 +86,7 @@ public extension Octokit {
                      pullRequestNumber: Int,
                      completion: @escaping (_ response: Result<[Review], Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = ReviewsRouter.listReviews(configuration, owner, repository, pullRequestNumber)
-        return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Review].self) { pullRequests, error in
+        return router.load(session, decoder: configuration.decoder, expectedResultType: [Review].self) { pullRequests, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -107,7 +107,7 @@ public extension Octokit {
                     comments: [Review.Comment] = [],
                     completion: @escaping (_ response: Result<Review, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = ReviewsRouter.postReview(configuration, owner, repository, pullRequestNumber, commitId, event, body, comments)
-        return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: Review.self) { pullRequest, error in
+        return router.load(session, decoder: configuration.decoder, expectedResultType: Review.self) { pullRequest, error in
             if let error = error {
                 completion(.failure(error))
             } else if let pullRequest = pullRequest {
@@ -123,7 +123,7 @@ public extension Octokit {
                              reviewId: Int,
                              completion: @escaping (_ response: Result<Review, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = ReviewsRouter.deletePendingReview(configuration, owner, repository, pullRequestNumber, reviewId)
-        return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: Review.self) { pullRequest, error in
+        return router.load(session, decoder: configuration.decoder, expectedResultType: Review.self) { pullRequest, error in
             if let error = error {
                 completion(.failure(error))
             } else if let pullRequest = pullRequest {
@@ -141,7 +141,7 @@ public extension Octokit {
                       body: String? = nil,
                       completion: @escaping (_ response: Result<Review, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = ReviewsRouter.submitReview(configuration, owner, repository, pullRequestNumber, reviewId, event, body)
-        return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: Review.self) { pullRequest, error in
+        return router.load(session, decoder: configuration.decoder, expectedResultType: Review.self) { pullRequest, error in
             if let error = error {
                 completion(.failure(error))
             } else if let pullRequest = pullRequest {
@@ -156,7 +156,7 @@ public extension Octokit {
                  repository: String,
                  pullRequestNumber: Int) async throws -> [Review] {
         let router = ReviewsRouter.listReviews(configuration, owner, repository, pullRequestNumber)
-        return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Review].self)
+        return try await router.load(session, decoder: configuration.decoder, expectedResultType: [Review].self)
     }
 
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
@@ -169,7 +169,7 @@ public extension Octokit {
                     body: String? = nil,
                     comments: [Review.Comment] = []) async throws -> Review {
         let router = ReviewsRouter.postReview(configuration, owner, repository, pullRequestNumber, commitId, event, body, comments)
-        return try await router.post(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: Review.self)
+        return try await router.post(session, decoder: configuration.decoder, expectedResultType: Review.self)
     }
 
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
@@ -179,7 +179,7 @@ public extension Octokit {
                              pullRequestNumber: Int,
                              reviewId: Int) async throws -> Review {
         let router = ReviewsRouter.deletePendingReview(configuration, owner, repository, pullRequestNumber, reviewId)
-        return try await router.post(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: Review.self)
+        return try await router.post(session, decoder: configuration.decoder, expectedResultType: Review.self)
     }
 
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
@@ -191,7 +191,7 @@ public extension Octokit {
                       event: Review.Event,
                       body: String? = nil) async throws -> Review {
         let router = ReviewsRouter.submitReview(configuration, owner, repository, pullRequestNumber, reviewId, event, body)
-        return try await router.post(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: Review.self)
+        return try await router.post(session, decoder: configuration.decoder, expectedResultType: Review.self)
     }
     #endif
 }

--- a/OctoKit/Search.swift
+++ b/OctoKit/Search.swift
@@ -97,7 +97,7 @@ public extension Octokit {
                     perPage: String = "100",
                     completion: @escaping (_ response: Result<SearchResponse<CodeSearchResultItem>, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = SearchRouter.searchCode(configuration, query, page, perPage)
-        return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: SearchResponse<CodeSearchResultItem>.self) { response, error in
+        return router.load(session, decoder: configuration.decoder, expectedResultType: SearchResponse<CodeSearchResultItem>.self) { response, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -118,7 +118,7 @@ public extension Octokit {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func searchCode(query: String, page: String = "1", perPage: String = "100") async throws -> SearchResponse<CodeSearchResultItem> {
         let router = SearchRouter.searchCode(configuration, query, page, perPage)
-        return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: SearchResponse<CodeSearchResultItem>.self)
+        return try await router.load(session, decoder: configuration.decoder, expectedResultType: SearchResponse<CodeSearchResultItem>.self)
     }
     #endif
 }

--- a/OctoKit/Stars.swift
+++ b/OctoKit/Stars.swift
@@ -13,7 +13,7 @@ public extension Octokit {
     @discardableResult
     func stars(name: String, completion: @escaping (_ response: Result<[Repository], Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = StarsRouter.readStars(name, configuration)
-        return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Repository].self) { repos, error in
+        return router.load(session, decoder: configuration.decoder, expectedResultType: [Repository].self) { repos, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -31,7 +31,7 @@ public extension Octokit {
     @discardableResult
     func myStars(completion: @escaping (_ response: Result<[Repository], Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = StarsRouter.readAuthenticatedStars(configuration)
-        return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Repository].self) { repos, error in
+        return router.load(session, decoder: configuration.decoder, expectedResultType: [Repository].self) { repos, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -104,7 +104,7 @@ public extension Octokit {
      */
     func stars(name: String) async throws -> [Repository] {
         let router = StarsRouter.readStars(name, configuration)
-        return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Repository].self)
+        return try await router.load(session, decoder: configuration.decoder, expectedResultType: [Repository].self)
     }
 
     /**
@@ -113,7 +113,7 @@ public extension Octokit {
      */
     func myStars() async throws -> [Repository] {
         let router = StarsRouter.readAuthenticatedStars(configuration)
-        return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Repository].self)
+        return try await router.load(session, decoder: configuration.decoder, expectedResultType: [Repository].self)
     }
 
     /**

--- a/OctoKit/Statuses.swift
+++ b/OctoKit/Statuses.swift
@@ -89,9 +89,7 @@ public extension Octokit {
                             context: String? = nil,
                             completion: @escaping (_ response: Result<Status, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = StatusesRouter.createCommitStatus(configuration, owner: owner, repo: repository, sha: sha, state: state, targetURL: targetURL, description: description, context: context)
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .formatted(Time.rfc3339DateFormatter)
-        return router.post(session, decoder: decoder, expectedResultType: Status.self) { status, error in
+        return router.post(session, decoder: configuration.decoder, expectedResultType: Status.self) { status, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -122,9 +120,7 @@ public extension Octokit {
                             description: String? = nil,
                             context: String? = nil) async throws -> Status {
         let router = StatusesRouter.createCommitStatus(configuration, owner: owner, repo: repository, sha: sha, state: state, targetURL: targetURL, description: description, context: context)
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .formatted(Time.rfc3339DateFormatter)
-        return try await router.post(session, decoder: decoder, expectedResultType: Status.self)
+        return try await router.post(session, decoder: configuration.decoder, expectedResultType: Status.self)
     }
     #endif
 
@@ -145,7 +141,7 @@ public extension Octokit {
                             perPage: String? = nil,
                             completion: @escaping (_ response: Result<[Status], Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = StatusesRouter.listCommitStatuses(configuration, owner: owner, repo: repository, ref: ref, page: page, perPage: perPage)
-        return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Status].self) { statuses, error in
+        return router.load(session, decoder: configuration.decoder, expectedResultType: [Status].self) { statuses, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -172,7 +168,7 @@ public extension Octokit {
                             page: String? = nil,
                             perPage: String? = nil) async throws -> [Status] {
         let router = StatusesRouter.listCommitStatuses(configuration, owner: owner, repo: repository, ref: ref, page: page, perPage: perPage)
-        return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: [Status].self)
+        return try await router.load(session, decoder: configuration.decoder, expectedResultType: [Status].self)
     }
     #endif
 }

--- a/OctoKit/User.swift
+++ b/OctoKit/User.swift
@@ -177,7 +177,7 @@ public extension Octokit {
     @discardableResult
     func user(id: Int, completion: @escaping (_ response: Result<User, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = UserRouter.readUserById(id, configuration)
-        return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: User.self) { user, error in
+        return router.load(session, decoder: configuration.decoder, expectedResultType: User.self) { user, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -196,7 +196,7 @@ public extension Octokit {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func user(id: Int) async throws -> User {
         let router = UserRouter.readUserById(id, configuration)
-        return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: User.self)
+        return try await router.load(session, decoder: configuration.decoder, expectedResultType: User.self)
     }
     #endif
 
@@ -208,7 +208,7 @@ public extension Octokit {
     @discardableResult
     func user(name: String, completion: @escaping (_ response: Result<User, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = UserRouter.readUserByName(name, configuration)
-        return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: User.self) { user, error in
+        return router.load(session, decoder: configuration.decoder, expectedResultType: User.self) { user, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -227,7 +227,7 @@ public extension Octokit {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func user(name: String) async throws -> User {
         let router = UserRouter.readUserByName(name, configuration)
-        return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: User.self)
+        return try await router.load(session, decoder: configuration.decoder, expectedResultType: User.self)
     }
     #endif
 
@@ -238,7 +238,7 @@ public extension Octokit {
     @discardableResult
     func me(completion: @escaping (_ response: Result<User, Error>) -> Void) -> URLSessionDataTaskProtocol? {
         let router = UserRouter.readAuthenticatedUser(configuration)
-        return router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: User.self) { user, error in
+        return router.load(session, decoder: configuration.decoder, expectedResultType: User.self) { user, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -256,7 +256,7 @@ public extension Octokit {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func me() async throws -> User {
         let router = UserRouter.readAuthenticatedUser(configuration)
-        return try await router.load(session, dateDecodingStrategy: .formatted(Time.rfc3339DateFormatter), expectedResultType: User.self)
+        return try await router.load(session, decoder: configuration.decoder, expectedResultType: User.self)
     }
     #endif
 }

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,25 +1,24 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "RequestKit",
-        "repositoryURL": "https://github.com/nerdishbynature/RequestKit.git",
-        "state": {
-          "branch": null,
-          "revision": "e4d905fed938807e36d87f28375f88b7c1c26840",
-          "version": "3.3.0"
-        }
-      },
-      {
-        "package": "SwiftFormat",
-        "repositoryURL": "https://github.com/nicklockwood/SwiftFormat",
-        "state": {
-          "branch": null,
-          "revision": "4c8386a35e6a287387da041794b71b85d0858760",
-          "version": "0.52.8"
-        }
+  "originHash" : "103d26dbf9e24efb90aca46eb3c94cf15e5847c3fc220990dd92f095ac2124cb",
+  "pins" : [
+    {
+      "identity" : "requestkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/nerdishbynature/RequestKit.git",
+      "state" : {
+        "revision" : "9d45c9aacc1d46c87def44dd120d9c71dab3c788",
+        "version" : "3.4.0"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "swiftformat",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/nicklockwood/SwiftFormat",
+      "state" : {
+        "revision" : "4c8386a35e6a287387da041794b71b85d0858760",
+        "version" : "0.52.8"
+      }
+    }
+  ],
+  "version" : 3
 }

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/nerdishbynature/RequestKit.git", from: "3.3.0"),
+        .package(url: "https://github.com/nerdishbynature/RequestKit.git", from: "3.4.0"),
         .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.52.8")
     ],
     targets: [


### PR DESCRIPTION
Bumps RequestKit dependency to 3.4.0. Adds a `decoder` computed property to `TokenConfiguration` with the rfc3339 date decoding strategy, then migrates all 13 source files to pass `decoder: configuration.decoder` explicitly at every load/post call site, removing ~60 lines of repeated local decoder construction.

Note: uses explicit `decoder:` arg rather than the 3.4.0 convenience overload to avoid a crash via protocol existential dispatch on this Swift toolchain.