### PR TITLE
Add paginated variants for list endpoints using RequestKit 3.4.0 load Paginated

### DIFF
--- a/OctoKit/Issue.swift
+++ b/OctoKit/Issue.swift
@@ -168,6 +168,31 @@ public extension Octokit {
     }
     #endif
 
+    @discardableResult
+    func myIssuesPaginated(state: Openness = .open,
+                           page: String = "1",
+                           perPage: String = "100",
+                           completion: @escaping (_ response: Result<PaginatedResponse<[Issue]>, Error>) -> Void) -> URLSessionDataTaskProtocol? {
+        let router = IssueRouter.readAuthenticatedIssues(configuration, page, perPage, state)
+        return router.loadPaginated(session, decoder: configuration.decoder, expectedResultType: [Issue].self) { response, error in
+            if let error = error {
+                completion(.failure(error))
+            } else if let response = response {
+                completion(.success(response))
+            }
+        }
+    }
+
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func myIssuesPaginated(state: Openness = .open,
+                           page: String = "1",
+                           perPage: String = "100") async throws -> PaginatedResponse<[Issue]> {
+        let router = IssueRouter.readAuthenticatedIssues(configuration, page, perPage, state)
+        return try await router.loadPaginated(session, decoder: configuration.decoder, expectedResultType: [Issue].self)
+    }
+    #endif
+
     /**
      Fetches an issue in a repository
      - parameter owner: The user or organization that owns the repository.
@@ -253,6 +278,35 @@ public extension Octokit {
                 perPage: String = "100") async throws -> [Issue] {
         let router = IssueRouter.readIssues(configuration, owner, repository, page, perPage, state)
         return try await router.load(session, decoder: configuration.decoder, expectedResultType: [Issue].self)
+    }
+    #endif
+
+    @discardableResult
+    func issuesPaginated(owner: String,
+                         repository: String,
+                         state: Openness = .open,
+                         page: String = "1",
+                         perPage: String = "100",
+                         completion: @escaping (_ response: Result<PaginatedResponse<[Issue]>, Error>) -> Void) -> URLSessionDataTaskProtocol? {
+        let router = IssueRouter.readIssues(configuration, owner, repository, page, perPage, state)
+        return router.loadPaginated(session, decoder: configuration.decoder, expectedResultType: [Issue].self) { response, error in
+            if let error = error {
+                completion(.failure(error))
+            } else if let response = response {
+                completion(.success(response))
+            }
+        }
+    }
+
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func issuesPaginated(owner: String,
+                         repository: String,
+                         state: Openness = .open,
+                         page: String = "1",
+                         perPage: String = "100") async throws -> PaginatedResponse<[Issue]> {
+        let router = IssueRouter.readIssues(configuration, owner, repository, page, perPage, state)
+        return try await router.loadPaginated(session, decoder: configuration.decoder, expectedResultType: [Issue].self)
     }
     #endif
 

--- a/OctoKit/Label.swift
+++ b/OctoKit/Label.swift
@@ -100,6 +100,30 @@ public extension Octokit {
     }
     #endif
 
+    @discardableResult
+    func labelsPaginated(owner: String,
+                         repository: String,
+                         page: String = "1",
+                         perPage: String = "100",
+                         completion: @escaping (_ response: Result<PaginatedResponse<[Label]>, Error>) -> Void) -> URLSessionDataTaskProtocol? {
+        let router = LabelRouter.readLabels(configuration, owner, repository, page, perPage)
+        return router.loadPaginated(session, decoder: configuration.decoder, expectedResultType: [Label].self) { response, error in
+            if let error = error {
+                completion(.failure(error))
+            } else if let response = response {
+                completion(.success(response))
+            }
+        }
+    }
+
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func labelsPaginated(owner: String, repository: String, page: String = "1", perPage: String = "100") async throws -> PaginatedResponse<[Label]> {
+        let router = LabelRouter.readLabels(configuration, owner, repository, page, perPage)
+        return try await router.loadPaginated(session, decoder: configuration.decoder, expectedResultType: [Label].self)
+    }
+    #endif
+
     /**
      Create a label in a repository
      - parameter owner: The user or organization that owns the repository.

--- a/OctoKit/NotificationThread.swift
+++ b/OctoKit/NotificationThread.swift
@@ -151,6 +151,33 @@ public extension Octokit {
     }
     #endif
 
+    @discardableResult
+    func myNotificationsPaginated(all: Bool = false,
+                                  participating: Bool = false,
+                                  page: String = "1",
+                                  perPage: String = "100",
+                                  completion: @escaping (_ response: Result<PaginatedResponse<[NotificationThread]>, Error>) -> Void) -> URLSessionDataTaskProtocol? {
+        let router = NotificationRouter.readNotifications(configuration, all, participating, page, perPage)
+        return router.loadPaginated(session, decoder: configuration.decoder, expectedResultType: [NotificationThread].self) { response, error in
+            if let error = error {
+                completion(.failure(error))
+            } else if let response = response {
+                completion(.success(response))
+            }
+        }
+    }
+
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func myNotificationsPaginated(all: Bool = false,
+                                  participating: Bool = false,
+                                  page: String = "1",
+                                  perPage: String = "100") async throws -> PaginatedResponse<[NotificationThread]> {
+        let router = NotificationRouter.readNotifications(configuration, all, participating, page, perPage)
+        return try await router.loadPaginated(session, decoder: configuration.decoder, expectedResultType: [NotificationThread].self)
+    }
+    #endif
+
     /**
      Marks All Notifications As read
      - parameter lastReadAt: Describes the last point that notifications were checked `last_read_at` by default.
@@ -407,6 +434,41 @@ public extension Octokit {
                                      perPage: String = "100") async throws -> [NotificationThread] {
         let router = NotificationRouter.listRepositoryNotifications(configuration, owner, repository, all, participating, since, before, perPage, page)
         return try await router.load(session, decoder: configuration.decoder, expectedResultType: [NotificationThread].self)
+    }
+    #endif
+
+    @discardableResult
+    func listRepositoryNotificationsPaginated(owner: String,
+                                              repository: String,
+                                              all: Bool = false,
+                                              participating: Bool = false,
+                                              since: String? = nil,
+                                              before: String? = nil,
+                                              page: String = "1",
+                                              perPage: String = "100",
+                                              completion: @escaping (_ response: Result<PaginatedResponse<[NotificationThread]>, Error>) -> Void) -> URLSessionDataTaskProtocol? {
+        let router = NotificationRouter.listRepositoryNotifications(configuration, owner, repository, all, participating, since, before, perPage, page)
+        return router.loadPaginated(session, decoder: configuration.decoder, expectedResultType: [NotificationThread].self) { response, error in
+            if let error = error {
+                completion(.failure(error))
+            } else if let response = response {
+                completion(.success(response))
+            }
+        }
+    }
+
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func listRepositoryNotificationsPaginated(owner: String,
+                                              repository: String,
+                                              all: Bool = false,
+                                              participating: Bool = false,
+                                              since: String? = nil,
+                                              before: String? = nil,
+                                              page: String = "1",
+                                              perPage: String = "100") async throws -> PaginatedResponse<[NotificationThread]> {
+        let router = NotificationRouter.listRepositoryNotifications(configuration, owner, repository, all, participating, since, before, perPage, page)
+        return try await router.loadPaginated(session, decoder: configuration.decoder, expectedResultType: [NotificationThread].self)
     }
     #endif
 

--- a/OctoKit/PullRequest.swift
+++ b/OctoKit/PullRequest.swift
@@ -394,6 +394,43 @@ public extension Octokit {
     }
     #endif
 
+    @discardableResult
+    func pullRequestsPaginated(owner: String,
+                               repository: String,
+                               base: String? = nil,
+                               head: String? = nil,
+                               state: Openness = .open,
+                               sort: SortType = .created,
+                               direction: SortDirection = .desc,
+                               page: String? = nil,
+                               perPage: String? = nil,
+                               completion: @escaping (_ response: Result<PaginatedResponse<[PullRequest]>, Error>) -> Void) -> URLSessionDataTaskProtocol? {
+        let router = PullRequestRouter.readPullRequests(configuration, owner, repository, base, head, state, sort, direction, page, perPage)
+        return router.loadPaginated(session, decoder: configuration.decoder, expectedResultType: [PullRequest].self) { response, error in
+            if let error = error {
+                completion(.failure(error))
+            } else if let response = response {
+                completion(.success(response))
+            }
+        }
+    }
+
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func pullRequestsPaginated(owner: String,
+                               repository: String,
+                               base: String? = nil,
+                               head: String? = nil,
+                               state: Openness = .open,
+                               sort: SortType = .created,
+                               direction: SortDirection = .desc,
+                               page: String? = nil,
+                               perPage: String? = nil) async throws -> PaginatedResponse<[PullRequest]> {
+        let router = PullRequestRouter.readPullRequests(configuration, owner, repository, base, head, state, sort, direction, page, perPage)
+        return try await router.loadPaginated(session, decoder: configuration.decoder, expectedResultType: [PullRequest].self)
+    }
+    #endif
+
     /**
      Updates a pull request
      - parameter owner: The user or organization that owns the repositories.

--- a/OctoKit/Releases.swift
+++ b/OctoKit/Releases.swift
@@ -149,6 +149,40 @@ public extension Octokit {
     }
     #endif
 
+    /// Fetches the list of releases with pagination info.
+    /// - Parameters:
+    ///   - owner: The user or organization that owns the repositories.
+    ///   - repository: The name of the repository.
+    ///   - perPage: Results per page (max 100). Default: `30`.
+    ///   - completion: Callback for the outcome of the fetch.
+    @discardableResult
+    func listReleasesPaginated(owner: String,
+                               repository: String,
+                               perPage: Int = 30,
+                               completion: @escaping (_ response: Result<PaginatedResponse<[Release]>, Error>) -> Void) -> URLSessionDataTaskProtocol? {
+        let router = ReleaseRouter.listReleases(configuration, owner, repository, perPage)
+        return router.loadPaginated(session, decoder: configuration.decoder, expectedResultType: [Release].self) { response, error in
+            if let error = error {
+                completion(.failure(error))
+            } else if let response = response {
+                completion(.success(response))
+            }
+        }
+    }
+
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
+    /// Fetches the list of releases with pagination info.
+    /// - Parameters:
+    ///   - owner: The user or organization that owns the repositories.
+    ///   - repository: The name of the repository.
+    ///   - perPage: Results per page (max 100). Default: `30`.
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func listReleasesPaginated(owner: String, repository: String, perPage: Int = 30) async throws -> PaginatedResponse<[Release]> {
+        let router = ReleaseRouter.listReleases(configuration, owner, repository, perPage)
+        return try await router.loadPaginated(session, decoder: configuration.decoder, expectedResultType: [Release].self)
+    }
+    #endif
+
     /// Creates a new release.
     /// - Parameters:
     ///   - owner: The user or organization that owns the repositories.

--- a/OctoKit/Repositories.swift
+++ b/OctoKit/Repositories.swift
@@ -264,6 +264,35 @@ public extension Octokit {
     }
     #endif
 
+    @discardableResult
+    func repositoriesPaginated(owner: String? = nil,
+                               page: String = "1",
+                               perPage: String = "100",
+                               completion: @escaping (_ response: Result<PaginatedResponse<[Repository]>, Error>) -> Void) -> URLSessionDataTaskProtocol? {
+        let router = (owner != nil)
+            ? RepositoryRouter.readRepositories(configuration, owner!, page, perPage)
+            : RepositoryRouter.readAuthenticatedRepositories(configuration, page, perPage)
+        return router.loadPaginated(session, decoder: configuration.decoder, expectedResultType: [Repository].self) { response, error in
+            if let error = error {
+                completion(.failure(error))
+            } else if let response = response {
+                completion(.success(response))
+            }
+        }
+    }
+
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func repositoriesPaginated(owner: String? = nil,
+                               page: String = "1",
+                               perPage: String = "100") async throws -> PaginatedResponse<[Repository]> {
+        let router = (owner != nil)
+            ? RepositoryRouter.readRepositories(configuration, owner!, page, perPage)
+            : RepositoryRouter.readAuthenticatedRepositories(configuration, page, perPage)
+        return try await router.loadPaginated(session, decoder: configuration.decoder, expectedResultType: [Repository].self)
+    }
+    #endif
+
     /**
          Fetches a repository for a user or organization
          - parameter owner: The user or organization that owns the repositories.

--- a/README.md
+++ b/README.md
@@ -391,3 +391,52 @@ Octokit().postRelease(owner: "octocat", repository: "Hello-World", tagName: "v1.
     }
 }
 ```
+
+## Pagination
+
+Several list endpoints have a `*Paginated` variant that returns a `PaginatedResponse<T>` containing both the decoded values and a `PageInfo` parsed from the GitHub `Link` response header.
+
+### Fetch a single page with pagination info
+
+```swift
+let config = TokenConfiguration(bearerToken: "your_token")
+Octokit(config).issuesPaginated(owner: "octocat", repository: "Hello-World") { response in
+    switch response {
+    case .success(let paginated):
+        let issues = paginated.values          // [Issue]
+        let hasMore = paginated.pageInfo.hasNextPage
+        let nextURL = paginated.pageInfo.next  // URL? pointing to the next page
+        // do something with issues
+    case .failure:
+        // handle any errors
+    }
+}
+```
+
+### Fetch all pages (async)
+
+```swift
+func allIssues(owner: String, repo: String) async throws -> [Issue] {
+    let config = TokenConfiguration(bearerToken: "your_token")
+    let octokit = Octokit(config)
+    var all: [Issue] = []
+    var page = "1"
+
+    while true {
+        let paginated = try await octokit.issuesPaginated(owner: owner, repository: repo, page: page)
+        all += paginated.values
+
+        guard paginated.pageInfo.hasNextPage,
+              let nextURL = paginated.pageInfo.next,
+              let components = URLComponents(url: nextURL, resolvingAgainstBaseURL: false),
+              let nextPage = components.queryItems?.first(where: { $0.name == "page" })?.value
+        else { break }
+
+        page = nextPage
+    }
+
+    return all
+}
+```
+
+Paginated variants are available for: `myIssuesPaginated`, `issuesPaginated`, `pullRequestsPaginated`, `repositoriesPaginated`, `myNotificationsPaginated`, `listRepositoryNotificationsPaginated`, `listReleasesPaginated`, `labelsPaginated`.

--- a/Tests/OctoKitTests/IssueTests.swift
+++ b/Tests/OctoKitTests/IssueTests.swift
@@ -165,6 +165,80 @@ class IssueTests: XCTestCase {
         XCTAssertTrue(session.wasCalled)
     }
 
+    // MARK: Pagination Tests
+
+    func testGetMyIssuesPaginated() {
+        let linkHeader = "<https://api.github.com/issues?page=2&per_page=100&state=open>; rel=\"next\""
+        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/issues?page=1&per_page=100&state=open",
+                                            expectedHTTPMethod: "GET",
+                                            jsonFile: "issues",
+                                            statusCode: 200,
+                                            responseHeaders: ["Content-Type": "application/json", "Link": linkHeader])
+        let task = Octokit(session: session).myIssuesPaginated { response in
+            switch response {
+            case let .success(paginated):
+                XCTAssertEqual(paginated.values.count, 1)
+                XCTAssertTrue(paginated.pageInfo.hasNextPage)
+            case let .failure(error):
+                XCTAssertNil(error)
+            }
+        }
+        XCTAssertNotNil(task)
+        XCTAssertTrue(session.wasCalled)
+    }
+
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func testGetMyIssuesPaginatedAsync() async throws {
+        let linkHeader = "<https://api.github.com/issues?page=2&per_page=100&state=open>; rel=\"next\""
+        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/issues?page=1&per_page=100&state=open",
+                                            expectedHTTPMethod: "GET",
+                                            jsonFile: "issues",
+                                            statusCode: 200,
+                                            responseHeaders: ["Content-Type": "application/json", "Link": linkHeader])
+        let paginated = try await Octokit(session: session).myIssuesPaginated()
+        XCTAssertEqual(paginated.values.count, 1)
+        XCTAssertTrue(paginated.pageInfo.hasNextPage)
+        XCTAssertTrue(session.wasCalled)
+    }
+    #endif
+
+    func testGetIssuesPaginated() {
+        let linkHeader = "<https://api.github.com/repos/octocat/Hello-World/issues?page=2&per_page=100&state=open>; rel=\"next\""
+        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/Hello-World/issues?page=1&per_page=100&state=open",
+                                            expectedHTTPMethod: "GET",
+                                            jsonFile: "issues",
+                                            statusCode: 200,
+                                            responseHeaders: ["Content-Type": "application/json", "Link": linkHeader])
+        let task = Octokit(session: session).issuesPaginated(owner: "octocat", repository: "Hello-World") { response in
+            switch response {
+            case let .success(paginated):
+                XCTAssertEqual(paginated.values.count, 1)
+                XCTAssertTrue(paginated.pageInfo.hasNextPage)
+            case let .failure(error):
+                XCTAssertNil(error)
+            }
+        }
+        XCTAssertNotNil(task)
+        XCTAssertTrue(session.wasCalled)
+    }
+
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func testGetIssuesPaginatedAsync() async throws {
+        let linkHeader = "<https://api.github.com/repos/octocat/Hello-World/issues?page=2&per_page=100&state=open>; rel=\"next\""
+        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/Hello-World/issues?page=1&per_page=100&state=open",
+                                            expectedHTTPMethod: "GET",
+                                            jsonFile: "issues",
+                                            statusCode: 200,
+                                            responseHeaders: ["Content-Type": "application/json", "Link": linkHeader])
+        let paginated = try await Octokit(session: session).issuesPaginated(owner: "octocat", repository: "Hello-World")
+        XCTAssertEqual(paginated.values.count, 1)
+        XCTAssertTrue(paginated.pageInfo.hasNextPage)
+        XCTAssertTrue(session.wasCalled)
+    }
+    #endif
+
     // MARK: Model Tests
 
     func testParsingIssue() {

--- a/Tests/OctoKitTests/LabelTests.swift
+++ b/Tests/OctoKitTests/LabelTests.swift
@@ -107,6 +107,42 @@ class LabelTests: XCTestCase {
     }
     #endif
 
+    func testLabelsPaginated() {
+        let linkHeader = "<https://api.github.com/repos/octocat/hello-world/labels?page=2&per_page=100>; rel=\"next\""
+        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/hello-world/labels?page=1&per_page=100",
+                                            expectedHTTPMethod: "GET",
+                                            jsonFile: "labels",
+                                            statusCode: 200,
+                                            responseHeaders: ["Content-Type": "application/json", "Link": linkHeader])
+        let task = Octokit(session: session).labelsPaginated(owner: "octocat", repository: "hello-world") { response in
+            switch response {
+            case let .success(paginated):
+                XCTAssertFalse(paginated.values.isEmpty)
+                XCTAssertTrue(paginated.pageInfo.hasNextPage)
+            case let .failure(error):
+                XCTAssertNil(error)
+            }
+        }
+        XCTAssertNotNil(task)
+        XCTAssertTrue(session.wasCalled)
+    }
+
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func testLabelsPaginatedAsync() async throws {
+        let linkHeader = "<https://api.github.com/repos/octocat/hello-world/labels?page=2&per_page=100>; rel=\"next\""
+        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/hello-world/labels?page=1&per_page=100",
+                                            expectedHTTPMethod: "GET",
+                                            jsonFile: "labels",
+                                            statusCode: 200,
+                                            responseHeaders: ["Content-Type": "application/json", "Link": linkHeader])
+        let paginated = try await Octokit(session: session).labelsPaginated(owner: "octocat", repository: "hello-world")
+        XCTAssertFalse(paginated.values.isEmpty)
+        XCTAssertTrue(paginated.pageInfo.hasNextPage)
+        XCTAssertTrue(session.wasCalled)
+    }
+    #endif
+
     // MARK: Parsing Tests
 
     func testParsingLabel() {

--- a/Tests/OctoKitTests/NotificationTests.swift
+++ b/Tests/OctoKitTests/NotificationTests.swift
@@ -277,4 +277,40 @@ class NotificationTests: XCTestCase {
         XCTAssertTrue(session.wasCalled)
     }
     #endif
+
+    func testMyNotificationsPaginated() {
+        let linkHeader = "<https://api.github.com/notifications?all=false&page=2&participating=false&per_page=100>; rel=\"next\""
+        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/notifications?all=false&page=1&participating=false&per_page=100",
+                                            expectedHTTPMethod: "GET",
+                                            jsonFile: "notification_threads",
+                                            statusCode: 200,
+                                            responseHeaders: ["Content-Type": "application/json", "Link": linkHeader])
+        let task = Octokit(session: session).myNotificationsPaginated { response in
+            switch response {
+            case let .success(paginated):
+                XCTAssertFalse(paginated.values.isEmpty)
+                XCTAssertTrue(paginated.pageInfo.hasNextPage)
+            case let .failure(error):
+                XCTAssertNil(error)
+            }
+        }
+        XCTAssertNotNil(task)
+        XCTAssertTrue(session.wasCalled)
+    }
+
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func testMyNotificationsPaginatedAsync() async throws {
+        let linkHeader = "<https://api.github.com/notifications?all=false&page=2&participating=false&per_page=100>; rel=\"next\""
+        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/notifications?all=false&page=1&participating=false&per_page=100",
+                                            expectedHTTPMethod: "GET",
+                                            jsonFile: "notification_threads",
+                                            statusCode: 200,
+                                            responseHeaders: ["Content-Type": "application/json", "Link": linkHeader])
+        let paginated = try await Octokit(session: session).myNotificationsPaginated()
+        XCTAssertFalse(paginated.values.isEmpty)
+        XCTAssertTrue(paginated.pageInfo.hasNextPage)
+        XCTAssertTrue(session.wasCalled)
+    }
+    #endif
 }

--- a/Tests/OctoKitTests/OctoKitURLTestSession.swift
+++ b/Tests/OctoKitTests/OctoKitURLTestSession.swift
@@ -19,16 +19,28 @@ class OctoKitURLTestSession: RequestKitURLSession {
     let expectedHTTPHeaders: [String: String]
     let responseString: String?
     let statusCode: Int
+    let responseHeaders: [String: String]
 
-    init(expectedURL: String, expectedHTTPMethod: String, expectedHTTPHeaders: [String: String] = [:], response: String?, statusCode: Int) {
+    init(expectedURL: String,
+         expectedHTTPMethod: String,
+         expectedHTTPHeaders: [String: String] = [:],
+         response: String?,
+         statusCode: Int,
+         responseHeaders: [String: String] = ["Content-Type": "application/json"]) {
         self.expectedURL = expectedURL
         self.expectedHTTPMethod = expectedHTTPMethod
         self.expectedHTTPHeaders = expectedHTTPHeaders
         responseString = response
         self.statusCode = statusCode
+        self.responseHeaders = responseHeaders
     }
 
-    init(expectedURL: String, expectedHTTPMethod: String, expectedHTTPHeaders: [String: String] = [:], jsonFile: String?, statusCode: Int) {
+    init(expectedURL: String,
+         expectedHTTPMethod: String,
+         expectedHTTPHeaders: [String: String] = [:],
+         jsonFile: String?,
+         statusCode: Int,
+         responseHeaders: [String: String] = ["Content-Type": "application/json"]) {
         self.expectedURL = expectedURL
         self.expectedHTTPMethod = expectedHTTPMethod
         self.expectedHTTPHeaders = expectedHTTPHeaders
@@ -38,6 +50,7 @@ class OctoKitURLTestSession: RequestKitURLSession {
             responseString = nil
         }
         self.statusCode = statusCode
+        self.responseHeaders = responseHeaders
     }
 
     func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTaskProtocol {
@@ -49,7 +62,7 @@ class OctoKitURLTestSession: RequestKitURLSession {
         }
 
         let data = responseString?.data(using: String.Encoding.utf8)
-        let response = HTTPURLResponse(url: request.url!, statusCode: statusCode, httpVersion: "http/1.1", headerFields: ["Content-Type": "application/json"])
+        let response = HTTPURLResponse(url: request.url!, statusCode: statusCode, httpVersion: "http/1.1", headerFields: responseHeaders)
         completionHandler(data, response, nil)
         wasCalled = true
         return MockURLSessionDataTask()
@@ -64,7 +77,7 @@ class OctoKitURLTestSession: RequestKitURLSession {
         }
 
         let data = responseString?.data(using: String.Encoding.utf8)
-        let response = HTTPURLResponse(url: request.url!, statusCode: statusCode, httpVersion: "http/1.1", headerFields: ["Content-Type": "application/json"])
+        let response = HTTPURLResponse(url: request.url!, statusCode: statusCode, httpVersion: "http/1.1", headerFields: responseHeaders)
         completionHandler(data, response, nil)
         wasCalled = true
         return MockURLSessionDataTask()
@@ -80,7 +93,7 @@ class OctoKitURLTestSession: RequestKitURLSession {
             XCTAssertEqual(request.allHTTPHeaderFields?[key], value)
         }
 
-        let response = HTTPURLResponse(url: request.url!, statusCode: statusCode, httpVersion: "http/1.1", headerFields: ["Content-Type": "application/json"])
+        let response = HTTPURLResponse(url: request.url!, statusCode: statusCode, httpVersion: "http/1.1", headerFields: responseHeaders)
         wasCalled = true
         return (responseString?.data(using: String.Encoding.utf8) ?? Data(), response!)
     }
@@ -94,7 +107,7 @@ class OctoKitURLTestSession: RequestKitURLSession {
             XCTAssertEqual(request.allHTTPHeaderFields?[key], value)
         }
 
-        let response = HTTPURLResponse(url: request.url!, statusCode: statusCode, httpVersion: "http/1.1", headerFields: ["Content-Type": "application/json"])
+        let response = HTTPURLResponse(url: request.url!, statusCode: statusCode, httpVersion: "http/1.1", headerFields: responseHeaders)
         wasCalled = true
         return (responseString?.data(using: String.Encoding.utf8) ?? Data(), response!)
     }

--- a/Tests/OctoKitTests/PullRequestTests.swift
+++ b/Tests/OctoKitTests/PullRequestTests.swift
@@ -603,4 +603,40 @@ class PullRequestTests: XCTestCase {
         XCTAssertTrue(session.wasCalled)
     }
     #endif
+
+    func testGetPullRequestsPaginated() {
+        let linkHeader = "<https://api.github.com/repos/octocat/Hello-World/pulls?direction=desc&sort=created&state=open&page=2>; rel=\"next\""
+        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/Hello-World/pulls?direction=desc&sort=created&state=open",
+                                            expectedHTTPMethod: "GET",
+                                            jsonFile: "pull_requests",
+                                            statusCode: 200,
+                                            responseHeaders: ["Content-Type": "application/json", "Link": linkHeader])
+        let task = Octokit(session: session).pullRequestsPaginated(owner: "octocat", repository: "Hello-World") { response in
+            switch response {
+            case let .success(paginated):
+                XCTAssertFalse(paginated.values.isEmpty)
+                XCTAssertTrue(paginated.pageInfo.hasNextPage)
+            case let .failure(error):
+                XCTAssertNil(error)
+            }
+        }
+        XCTAssertNotNil(task)
+        XCTAssertTrue(session.wasCalled)
+    }
+
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func testGetPullRequestsPaginatedAsync() async throws {
+        let linkHeader = "<https://api.github.com/repos/octocat/Hello-World/pulls?direction=desc&sort=created&state=open&page=2>; rel=\"next\""
+        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/Hello-World/pulls?direction=desc&sort=created&state=open",
+                                            expectedHTTPMethod: "GET",
+                                            jsonFile: "pull_requests",
+                                            statusCode: 200,
+                                            responseHeaders: ["Content-Type": "application/json", "Link": linkHeader])
+        let paginated = try await Octokit(session: session).pullRequestsPaginated(owner: "octocat", repository: "Hello-World")
+        XCTAssertFalse(paginated.values.isEmpty)
+        XCTAssertTrue(paginated.pageInfo.hasNextPage)
+        XCTAssertTrue(session.wasCalled)
+    }
+    #endif
 }

--- a/Tests/OctoKitTests/ReleasesTests.swift
+++ b/Tests/OctoKitTests/ReleasesTests.swift
@@ -209,4 +209,40 @@ final class ReleasesTests: XCTestCase {
         XCTAssertTrue(session.wasCalled)
     }
     #endif
+
+    func testListReleasesPaginated() {
+        let linkHeader = "<https://api.github.com/repos/octocat/Hello-World/releases?page=2&per_page=30>; rel=\"next\""
+        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/Hello-World/releases?per_page=30",
+                                            expectedHTTPMethod: "GET",
+                                            jsonFile: "releases",
+                                            statusCode: 200,
+                                            responseHeaders: ["Content-Type": "application/json", "Link": linkHeader])
+        let task = Octokit(session: session).listReleasesPaginated(owner: "octocat", repository: "Hello-World") { response in
+            switch response {
+            case let .success(paginated):
+                XCTAssertFalse(paginated.values.isEmpty)
+                XCTAssertTrue(paginated.pageInfo.hasNextPage)
+            case let .failure(error):
+                XCTAssertNil(error)
+            }
+        }
+        XCTAssertNotNil(task)
+        XCTAssertTrue(session.wasCalled)
+    }
+
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func testListReleasesPaginatedAsync() async throws {
+        let linkHeader = "<https://api.github.com/repos/octocat/Hello-World/releases?page=2&per_page=30>; rel=\"next\""
+        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/Hello-World/releases?per_page=30",
+                                            expectedHTTPMethod: "GET",
+                                            jsonFile: "releases",
+                                            statusCode: 200,
+                                            responseHeaders: ["Content-Type": "application/json", "Link": linkHeader])
+        let paginated = try await Octokit(session: session).listReleasesPaginated(owner: "octocat", repository: "Hello-World")
+        XCTAssertFalse(paginated.values.isEmpty)
+        XCTAssertTrue(paginated.pageInfo.hasNextPage)
+        XCTAssertTrue(session.wasCalled)
+    }
+    #endif
 }

--- a/Tests/OctoKitTests/RepositoryTests.swift
+++ b/Tests/OctoKitTests/RepositoryTests.swift
@@ -453,4 +453,40 @@ class RepositoryTests: XCTestCase {
         XCTAssertEqual(submoduleContent.links.html, "https://github.com/muter-mutation-testing/homebrew-formulae/tree/4e30ce4a9b6137502cf131664d412000bdd93007")
         XCTAssertEqual(submoduleContent.links.selfLink, "https://api.github.com/repos/muter-mutation-testing/muter/contents/homebrew-formulae?ref=master")
     }
+
+    func testRepositoriesPaginated() {
+        let linkHeader = "<https://api.github.com/users/octocat/repos?page=2&per_page=100>; rel=\"next\""
+        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/users/octocat/repos?page=1&per_page=100",
+                                            expectedHTTPMethod: "GET",
+                                            jsonFile: "user_repos",
+                                            statusCode: 200,
+                                            responseHeaders: ["Content-Type": "application/json", "Link": linkHeader])
+        let task = Octokit(session: session).repositoriesPaginated(owner: "octocat") { response in
+            switch response {
+            case let .success(paginated):
+                XCTAssertFalse(paginated.values.isEmpty)
+                XCTAssertTrue(paginated.pageInfo.hasNextPage)
+            case let .failure(error):
+                XCTAssertNil(error)
+            }
+        }
+        XCTAssertNotNil(task)
+        XCTAssertTrue(session.wasCalled)
+    }
+
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func testRepositoriesPaginatedAsync() async throws {
+        let linkHeader = "<https://api.github.com/users/octocat/repos?page=2&per_page=100>; rel=\"next\""
+        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/users/octocat/repos?page=1&per_page=100",
+                                            expectedHTTPMethod: "GET",
+                                            jsonFile: "user_repos",
+                                            statusCode: 200,
+                                            responseHeaders: ["Content-Type": "application/json", "Link": linkHeader])
+        let paginated = try await Octokit(session: session).repositoriesPaginated(owner: "octocat")
+        XCTAssertFalse(paginated.values.isEmpty)
+        XCTAssertTrue(paginated.pageInfo.hasNextPage)
+        XCTAssertTrue(session.wasCalled)
+    }
+    #endif
 }


### PR DESCRIPTION
Adds *Paginated methods (callback + async) for: myIssues, issues, pullRequests, repositories, myNotifications, listRepositoryNotifications, listReleases, labels. Each returns PaginatedResponse<T> with PageInfo parsed from RFC 5988 Link header.

Updates OctoKitURLTestSession to accept responseHeaders so tests can inject Link headers and assert pageInfo.hasNextPage. Adds README pagination section with single-page and fetch-all-pages examples.