### PR TITLE
Add repository tags endpoint with CLI and tests

### DIFF
--- a/OctoKit/Repositories.swift
+++ b/OctoKit/Repositories.swift
@@ -168,6 +168,27 @@ public struct Topics: Codable {
     }
 }
 
+public struct TagCommit: Codable {
+    public let sha: String
+    public let url: String
+}
+
+public struct RepositoryTag: Codable {
+    public let name: String
+    public let commit: TagCommit
+    public let zipballURL: String
+    public let tarballURL: String
+    public let nodeID: String
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case commit
+        case zipballURL = "zipball_url"
+        case tarballURL = "tarball_url"
+        case nodeID = "node_id"
+    }
+}
+
 public struct SubmoduleContent: Codable {
     public let type: String
     public let submoduleGitUrl: String
@@ -389,6 +410,57 @@ public extension Octokit {
         }
     }
 
+    @discardableResult
+    func tags(owner: String,
+              name: String,
+              page: String = "1",
+              perPage: String = "100",
+              completion: @escaping (_ response: Result<[RepositoryTag], Error>) -> Void) -> URLSessionDataTaskProtocol? {
+        let router = RepositoryRouter.listTags(configuration, owner, name, page, perPage)
+        return router.load(session, decoder: configuration.decoder, expectedResultType: [RepositoryTag].self) { tags, error in
+            if let error = error {
+                completion(.failure(error))
+            } else if let tags = tags {
+                completion(.success(tags))
+            }
+        }
+    }
+
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func tags(owner: String, name: String, page: String = "1", perPage: String = "100") async throws -> [RepositoryTag] {
+        let router = RepositoryRouter.listTags(configuration, owner, name, page, perPage)
+        return try await router.load(session, decoder: configuration.decoder, expectedResultType: [RepositoryTag].self)
+    }
+    #endif
+
+    @discardableResult
+    func tagsPaginated(owner: String,
+                       name: String,
+                       page: String = "1",
+                       perPage: String = "100",
+                       completion: @escaping (_ response: Result<PaginatedResponse<[RepositoryTag]>, Error>) -> Void) -> URLSessionDataTaskProtocol? {
+        let router = RepositoryRouter.listTags(configuration, owner, name, page, perPage)
+        return router.loadPaginated(session, decoder: configuration.decoder, expectedResultType: [RepositoryTag].self) { response, error in
+            if let error = error {
+                completion(.failure(error))
+            } else if let response = response {
+                completion(.success(response))
+            }
+        }
+    }
+
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func tagsPaginated(owner: String,
+                       name: String,
+                       page: String = "1",
+                       perPage: String = "100") async throws -> PaginatedResponse<[RepositoryTag]> {
+        let router = RepositoryRouter.listTags(configuration, owner, name, page, perPage)
+        return try await router.loadPaginated(session, decoder: configuration.decoder, expectedResultType: [RepositoryTag].self)
+    }
+    #endif
+
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     /**
          Gets the contents of a file or directory in a repository.
@@ -414,6 +486,7 @@ enum RepositoryRouter: Router {
     case readRepository(Configuration, String, String)
     case getRepositoryContent(Configuration, String, String, String?, String?)
     case getRepositoryTopics(Configuration, owner: String, name: String)
+    case listTags(Configuration, String, String, String, String)
 
     var configuration: Configuration {
         switch self {
@@ -422,6 +495,7 @@ enum RepositoryRouter: Router {
         case let .readRepository(config, _, _): return config
         case let .getRepositoryContent(config, _, _, _, _): return config
         case let .getRepositoryTopics(config, _, _): return config
+        case let .listTags(config, _, _, _, _): return config
         }
     }
 
@@ -448,6 +522,8 @@ enum RepositoryRouter: Router {
             return [:]
         case .getRepositoryTopics:
             return [:]
+        case let .listTags(_, _, _, page, perPage):
+            return ["per_page": perPage, "page": page]
         }
     }
 
@@ -465,6 +541,8 @@ enum RepositoryRouter: Router {
             return path
         case let .getRepositoryTopics(_, owner, name):
             return "repos/\(owner)/\(name)/topics"
+        case let .listTags(_, owner, name, _, _):
+            return "repos/\(owner)/\(name)/tags"
         }
     }
 }

--- a/OctoKitCLI/Sources/OctoKitCLI/Modules/Repository.swift
+++ b/OctoKitCLI/Sources/OctoKitCLI/Modules/Repository.swift
@@ -17,7 +17,8 @@ struct Repository: AsyncParsableCommand {
                                                         Get.self,
                                                         GetList.self,
                                                         GetTopics.self,
-                                                        GetContent.self
+                                                        GetContent.self,
+                                                        GetTags.self
                                                     ])
 
     init() {}
@@ -89,6 +90,30 @@ extension Repository {
             let session = JSONInterceptingURLSession()
             let octokit = makeOctokit(session: session)
             _ = try await octokit.repositoryTopics(owner: owner, name: name)
+            session.verbosePrint(verbose: verbose)
+            try session.printResponseToFileOrConsole(filePath: filePath)
+        }
+    }
+
+    struct GetTags: AsyncParsableCommand {
+        @Argument(help: "The owner of the repository")
+        var owner: String
+
+        @Argument(help: "The name of the repository")
+        var name: String
+
+        @Argument(help: "The path to put the file in")
+        var filePath: String?
+
+        @Flag(help: "Verbose output flag")
+        var verbose: Bool = false
+
+        init() {}
+
+        mutating func run() async throws {
+            let session = JSONInterceptingURLSession()
+            let octokit = Octokit(session: session)
+            _ = try await octokit.tags(owner: owner, name: name)
             session.verbosePrint(verbose: verbose)
             try session.printResponseToFileOrConsole(filePath: filePath)
         }

--- a/Tests/OctoKitTests/Fixtures/tags.json
+++ b/Tests/OctoKitTests/Fixtures/tags.json
@@ -1,22 +1,312 @@
 [
   {
-    "commit": {
-      "sha": "c5b97d5ae6c19d5c5df71a34c7fbeeda2479ccbc",
-      "url": "https:\/\/api.github.com\/repos\/octocat\/Hello-World\/commits\/c5b97d5ae6c19d5c5df71a34c7fbeeda2479ccbc"
+    "commit" : {
+      "sha" : "cd108b387782d8509e64e298cf4800dc47fc40ae",
+      "url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/commits\/cd108b387782d8509e64e298cf4800dc47fc40ae"
     },
-    "name": "v0.1",
-    "node_id": "MDM6UmVmMTI5NjI3NDpyZWZzL3RhZ3MvdjAuMQ==",
-    "tarball_url": "https:\/\/github.com\/octocat\/Hello-World\/tarball\/v0.1",
-    "zipball_url": "https:\/\/github.com\/octocat\/Hello-World\/zipball\/v0.1"
+    "name" : "0.14.0",
+    "node_id" : "MDM6UmVmMjkxNTI4OTI6cmVmcy90YWdzLzAuMTQuMA==",
+    "tarball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/tarball\/refs\/tags\/0.14.0",
+    "zipball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/zipball\/refs\/tags\/0.14.0"
   },
   {
-    "commit": {
-      "sha": "a10867b14bb761a232cd80139fbd4c0d33264240",
-      "url": "https:\/\/api.github.com\/repos\/octocat\/Hello-World\/commits\/a10867b14bb761a232cd80139fbd4c0d33264240"
+    "commit" : {
+      "sha" : "44192458beb89180c3a3a1245d904aacac8be0ae",
+      "url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/commits\/44192458beb89180c3a3a1245d904aacac8be0ae"
     },
-    "name": "v0.2",
-    "node_id": "MDM6UmVmMTI5NjI3NDpyZWZzL3RhZ3MvdjAuMg==",
-    "tarball_url": "https:\/\/github.com\/octocat\/Hello-World\/tarball\/v0.2",
-    "zipball_url": "https:\/\/github.com\/octocat\/Hello-World\/zipball\/v0.2"
+    "name" : "0.13.0",
+    "node_id" : "MDM6UmVmMjkxNTI4OTI6cmVmcy90YWdzLzAuMTMuMA==",
+    "tarball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/tarball\/refs\/tags\/0.13.0",
+    "zipball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/zipball\/refs\/tags\/0.13.0"
+  },
+  {
+    "commit" : {
+      "sha" : "f762f1566f7cd0e683b9329f169c28ab6ef993cc",
+      "url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/commits\/f762f1566f7cd0e683b9329f169c28ab6ef993cc"
+    },
+    "name" : "0.12.0",
+    "node_id" : "MDM6UmVmMjkxNTI4OTI6cmVmcy90YWdzLzAuMTIuMA==",
+    "tarball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/tarball\/refs\/tags\/0.12.0",
+    "zipball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/zipball\/refs\/tags\/0.12.0"
+  },
+  {
+    "commit" : {
+      "sha" : "9521cdff919053868ab13cd08a228f7bc1bde2a9",
+      "url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/commits\/9521cdff919053868ab13cd08a228f7bc1bde2a9"
+    },
+    "name" : "0.11.0",
+    "node_id" : "MDM6UmVmMjkxNTI4OTI6cmVmcy90YWdzLzAuMTEuMA==",
+    "tarball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/tarball\/refs\/tags\/0.11.0",
+    "zipball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/zipball\/refs\/tags\/0.11.0"
+  },
+  {
+    "commit" : {
+      "sha" : "c391cfba4d33f3f4c7d7d8fa6708970f7d30af82",
+      "url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/commits\/c391cfba4d33f3f4c7d7d8fa6708970f7d30af82"
+    },
+    "name" : "0.10.1",
+    "node_id" : "MDM6UmVmMjkxNTI4OTI6cmVmcy90YWdzLzAuMTAuMQ==",
+    "tarball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/tarball\/refs\/tags\/0.10.1",
+    "zipball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/zipball\/refs\/tags\/0.10.1"
+  },
+  {
+    "commit" : {
+      "sha" : "9ad4d6eff94ad1d9873d3b410a47c663c820d4bd",
+      "url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/commits\/9ad4d6eff94ad1d9873d3b410a47c663c820d4bd"
+    },
+    "name" : "0.10.0",
+    "node_id" : "MDM6UmVmMjkxNTI4OTI6cmVmcy90YWdzLzAuMTAuMA==",
+    "tarball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/tarball\/refs\/tags\/0.10.0",
+    "zipball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/zipball\/refs\/tags\/0.10.0"
+  },
+  {
+    "commit" : {
+      "sha" : "b63f2ec1b55f26c8e94159d81ad695aeb92f3d4e",
+      "url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/commits\/b63f2ec1b55f26c8e94159d81ad695aeb92f3d4e"
+    },
+    "name" : "0.9.0",
+    "node_id" : "MDM6UmVmMjkxNTI4OTI6cmVmcy90YWdzLzAuOS4w",
+    "tarball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/tarball\/refs\/tags\/0.9.0",
+    "zipball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/zipball\/refs\/tags\/0.9.0"
+  },
+  {
+    "commit" : {
+      "sha" : "a66069e3d4f1e5eb498d27d966a291ec24a679e7",
+      "url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/commits\/a66069e3d4f1e5eb498d27d966a291ec24a679e7"
+    },
+    "name" : "0.8.0",
+    "node_id" : "MDM6UmVmMjkxNTI4OTI6cmVmcy90YWdzLzAuOC4w",
+    "tarball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/tarball\/refs\/tags\/0.8.0",
+    "zipball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/zipball\/refs\/tags\/0.8.0"
+  },
+  {
+    "commit" : {
+      "sha" : "8592716acb1334591a9be9847d6fefdabd61e002",
+      "url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/commits\/8592716acb1334591a9be9847d6fefdabd61e002"
+    },
+    "name" : "0.7.4",
+    "node_id" : "MDM6UmVmMjkxNTI4OTI6cmVmcy90YWdzLzAuNy40",
+    "tarball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/tarball\/refs\/tags\/0.7.4",
+    "zipball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/zipball\/refs\/tags\/0.7.4"
+  },
+  {
+    "commit" : {
+      "sha" : "0d5b08ddd004b02ffa2e24e78d0fe9e58fdb1ff0",
+      "url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/commits\/0d5b08ddd004b02ffa2e24e78d0fe9e58fdb1ff0"
+    },
+    "name" : "0.7.3",
+    "node_id" : "MDM6UmVmMjkxNTI4OTI6cmVmcy90YWdzLzAuNy4z",
+    "tarball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/tarball\/refs\/tags\/0.7.3",
+    "zipball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/zipball\/refs\/tags\/0.7.3"
+  },
+  {
+    "commit" : {
+      "sha" : "c132bfec08c2377ef5f87c57f1014b5844f9cf76",
+      "url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/commits\/c132bfec08c2377ef5f87c57f1014b5844f9cf76"
+    },
+    "name" : "0.7.2",
+    "node_id" : "MDM6UmVmMjkxNTI4OTI6cmVmcy90YWdzLzAuNy4y",
+    "tarball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/tarball\/refs\/tags\/0.7.2",
+    "zipball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/zipball\/refs\/tags\/0.7.2"
+  },
+  {
+    "commit" : {
+      "sha" : "39e039cf4913ed2cbd658853131ea4eb4303f19d",
+      "url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/commits\/39e039cf4913ed2cbd658853131ea4eb4303f19d"
+    },
+    "name" : "0.7.1",
+    "node_id" : "MDM6UmVmMjkxNTI4OTI6cmVmcy90YWdzLzAuNy4x",
+    "tarball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/tarball\/refs\/tags\/0.7.1",
+    "zipball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/zipball\/refs\/tags\/0.7.1"
+  },
+  {
+    "commit" : {
+      "sha" : "09254f4374818f917f5ba04eeb9d89041c5a2068",
+      "url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/commits\/09254f4374818f917f5ba04eeb9d89041c5a2068"
+    },
+    "name" : "0.7.0",
+    "node_id" : "MDM6UmVmMjkxNTI4OTI6cmVmcy90YWdzLzAuNy4w",
+    "tarball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/tarball\/refs\/tags\/0.7.0",
+    "zipball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/zipball\/refs\/tags\/0.7.0"
+  },
+  {
+    "commit" : {
+      "sha" : "366809ea1afc516882317e67db585260ae61504b",
+      "url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/commits\/366809ea1afc516882317e67db585260ae61504b"
+    },
+    "name" : "0.6.3",
+    "node_id" : "MDM6UmVmMjkxNTI4OTI6cmVmcy90YWdzLzAuNi4z",
+    "tarball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/tarball\/refs\/tags\/0.6.3",
+    "zipball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/zipball\/refs\/tags\/0.6.3"
+  },
+  {
+    "commit" : {
+      "sha" : "a225ca99df370c2ba2fab9a523cc3d1e19d9ccb9",
+      "url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/commits\/a225ca99df370c2ba2fab9a523cc3d1e19d9ccb9"
+    },
+    "name" : "0.6.2",
+    "node_id" : "MDM6UmVmMjkxNTI4OTI6cmVmcy90YWdzLzAuNi4y",
+    "tarball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/tarball\/refs\/tags\/0.6.2",
+    "zipball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/zipball\/refs\/tags\/0.6.2"
+  },
+  {
+    "commit" : {
+      "sha" : "916a5a6ab79aa9c31febd0ceb631cc18584984ab",
+      "url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/commits\/916a5a6ab79aa9c31febd0ceb631cc18584984ab"
+    },
+    "name" : "0.6.1",
+    "node_id" : "MDM6UmVmMjkxNTI4OTI6cmVmcy90YWdzLzAuNi4x",
+    "tarball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/tarball\/refs\/tags\/0.6.1",
+    "zipball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/zipball\/refs\/tags\/0.6.1"
+  },
+  {
+    "commit" : {
+      "sha" : "abc3cb2ac8058c45413d98b21a073bdc4dc028b2",
+      "url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/commits\/abc3cb2ac8058c45413d98b21a073bdc4dc028b2"
+    },
+    "name" : "0.6.0",
+    "node_id" : "MDM6UmVmMjkxNTI4OTI6cmVmcy90YWdzLzAuNi4w",
+    "tarball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/tarball\/refs\/tags\/0.6.0",
+    "zipball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/zipball\/refs\/tags\/0.6.0"
+  },
+  {
+    "commit" : {
+      "sha" : "67eabf22b156fe30db1695dba18df7ec0f5ea0a7",
+      "url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/commits\/67eabf22b156fe30db1695dba18df7ec0f5ea0a7"
+    },
+    "name" : "0.5.2",
+    "node_id" : "MDM6UmVmMjkxNTI4OTI6cmVmcy90YWdzLzAuNS4y",
+    "tarball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/tarball\/refs\/tags\/0.5.2",
+    "zipball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/zipball\/refs\/tags\/0.5.2"
+  },
+  {
+    "commit" : {
+      "sha" : "ff8bc4fbdf37353f0e292fc785546e5fd8328829",
+      "url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/commits\/ff8bc4fbdf37353f0e292fc785546e5fd8328829"
+    },
+    "name" : "0.5.1",
+    "node_id" : "MDM6UmVmMjkxNTI4OTI6cmVmcy90YWdzLzAuNS4x",
+    "tarball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/tarball\/refs\/tags\/0.5.1",
+    "zipball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/zipball\/refs\/tags\/0.5.1"
+  },
+  {
+    "commit" : {
+      "sha" : "be366d644273bc4d7d008d3c047ddea673f36ab3",
+      "url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/commits\/be366d644273bc4d7d008d3c047ddea673f36ab3"
+    },
+    "name" : "0.5.0",
+    "node_id" : "MDM6UmVmMjkxNTI4OTI6cmVmcy90YWdzLzAuNS4w",
+    "tarball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/tarball\/refs\/tags\/0.5.0",
+    "zipball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/zipball\/refs\/tags\/0.5.0"
+  },
+  {
+    "commit" : {
+      "sha" : "1a3fdce8067ac8de9e378f743d2f8fe1e83c5865",
+      "url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/commits\/1a3fdce8067ac8de9e378f743d2f8fe1e83c5865"
+    },
+    "name" : "0.4.0",
+    "node_id" : "MDM6UmVmMjkxNTI4OTI6cmVmcy90YWdzLzAuNC4w",
+    "tarball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/tarball\/refs\/tags\/0.4.0",
+    "zipball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/zipball\/refs\/tags\/0.4.0"
+  },
+  {
+    "commit" : {
+      "sha" : "caef63ffd8dd90f90e661065c6a87931ac3aba18",
+      "url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/commits\/caef63ffd8dd90f90e661065c6a87931ac3aba18"
+    },
+    "name" : "0.3.2",
+    "node_id" : "MDM6UmVmMjkxNTI4OTI6cmVmcy90YWdzLzAuMy4y",
+    "tarball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/tarball\/refs\/tags\/0.3.2",
+    "zipball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/zipball\/refs\/tags\/0.3.2"
+  },
+  {
+    "commit" : {
+      "sha" : "528e5f435e303ab3125da76a75654ac76ad1df5c",
+      "url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/commits\/528e5f435e303ab3125da76a75654ac76ad1df5c"
+    },
+    "name" : "0.3.1",
+    "node_id" : "MDM6UmVmMjkxNTI4OTI6cmVmcy90YWdzLzAuMy4x",
+    "tarball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/tarball\/refs\/tags\/0.3.1",
+    "zipball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/zipball\/refs\/tags\/0.3.1"
+  },
+  {
+    "commit" : {
+      "sha" : "d78046ba2a3ebe3fd5322a570a86ef405fd09d8c",
+      "url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/commits\/d78046ba2a3ebe3fd5322a570a86ef405fd09d8c"
+    },
+    "name" : "0.3.0",
+    "node_id" : "MDM6UmVmMjkxNTI4OTI6cmVmcy90YWdzLzAuMy4w",
+    "tarball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/tarball\/refs\/tags\/0.3.0",
+    "zipball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/zipball\/refs\/tags\/0.3.0"
+  },
+  {
+    "commit" : {
+      "sha" : "050fdbb9ce0340b755dd6b7c9467d3130fe83599",
+      "url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/commits\/050fdbb9ce0340b755dd6b7c9467d3130fe83599"
+    },
+    "name" : "0.2.5",
+    "node_id" : "MDM6UmVmMjkxNTI4OTI6cmVmcy90YWdzLzAuMi41",
+    "tarball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/tarball\/refs\/tags\/0.2.5",
+    "zipball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/zipball\/refs\/tags\/0.2.5"
+  },
+  {
+    "commit" : {
+      "sha" : "733f6f7ee4a86eb6c0371fb6b6a2c88b95d05fe8",
+      "url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/commits\/733f6f7ee4a86eb6c0371fb6b6a2c88b95d05fe8"
+    },
+    "name" : "0.2.4",
+    "node_id" : "MDM6UmVmMjkxNTI4OTI6cmVmcy90YWdzLzAuMi40",
+    "tarball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/tarball\/refs\/tags\/0.2.4",
+    "zipball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/zipball\/refs\/tags\/0.2.4"
+  },
+  {
+    "commit" : {
+      "sha" : "786a65fec263c8308672c481175ef5980d4f2d8e",
+      "url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/commits\/786a65fec263c8308672c481175ef5980d4f2d8e"
+    },
+    "name" : "0.2.3",
+    "node_id" : "MDM6UmVmMjkxNTI4OTI6cmVmcy90YWdzLzAuMi4z",
+    "tarball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/tarball\/refs\/tags\/0.2.3",
+    "zipball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/zipball\/refs\/tags\/0.2.3"
+  },
+  {
+    "commit" : {
+      "sha" : "5ae05165a7dbe97daf3c8b27f90c577358d3c474",
+      "url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/commits\/5ae05165a7dbe97daf3c8b27f90c577358d3c474"
+    },
+    "name" : "0.2.2",
+    "node_id" : "MDM6UmVmMjkxNTI4OTI6cmVmcy90YWdzLzAuMi4y",
+    "tarball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/tarball\/refs\/tags\/0.2.2",
+    "zipball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/zipball\/refs\/tags\/0.2.2"
+  },
+  {
+    "commit" : {
+      "sha" : "bb98e35a1658fa16df2aa6a65f016997fb142c4b",
+      "url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/commits\/bb98e35a1658fa16df2aa6a65f016997fb142c4b"
+    },
+    "name" : "0.2.1",
+    "node_id" : "MDM6UmVmMjkxNTI4OTI6cmVmcy90YWdzLzAuMi4x",
+    "tarball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/tarball\/refs\/tags\/0.2.1",
+    "zipball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/zipball\/refs\/tags\/0.2.1"
+  },
+  {
+    "commit" : {
+      "sha" : "10f5db03f8782ad1c2d4c42b6f341da9cdf822b4",
+      "url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/commits\/10f5db03f8782ad1c2d4c42b6f341da9cdf822b4"
+    },
+    "name" : "0.2.0",
+    "node_id" : "MDM6UmVmMjkxNTI4OTI6cmVmcy90YWdzLzAuMi4w",
+    "tarball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/tarball\/refs\/tags\/0.2.0",
+    "zipball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/zipball\/refs\/tags\/0.2.0"
+  },
+  {
+    "commit" : {
+      "sha" : "172c4eee384975230760429f0ff8e1c140a1cf23",
+      "url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/commits\/172c4eee384975230760429f0ff8e1c140a1cf23"
+    },
+    "name" : "0.1.0",
+    "node_id" : "MDM6UmVmMjkxNTI4OTI6cmVmcy90YWdzLzAuMS4w",
+    "tarball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/tarball\/refs\/tags\/0.1.0",
+    "zipball_url" : "https:\/\/api.github.com\/repos\/nerdishbynature\/octokit.swift\/zipball\/refs\/tags\/0.1.0"
   }
 ]

--- a/Tests/OctoKitTests/Fixtures/tags.json
+++ b/Tests/OctoKitTests/Fixtures/tags.json
@@ -1,0 +1,22 @@
+[
+  {
+    "commit": {
+      "sha": "c5b97d5ae6c19d5c5df71a34c7fbeeda2479ccbc",
+      "url": "https:\/\/api.github.com\/repos\/octocat\/Hello-World\/commits\/c5b97d5ae6c19d5c5df71a34c7fbeeda2479ccbc"
+    },
+    "name": "v0.1",
+    "node_id": "MDM6UmVmMTI5NjI3NDpyZWZzL3RhZ3MvdjAuMQ==",
+    "tarball_url": "https:\/\/github.com\/octocat\/Hello-World\/tarball\/v0.1",
+    "zipball_url": "https:\/\/github.com\/octocat\/Hello-World\/zipball\/v0.1"
+  },
+  {
+    "commit": {
+      "sha": "a10867b14bb761a232cd80139fbd4c0d33264240",
+      "url": "https:\/\/api.github.com\/repos\/octocat\/Hello-World\/commits\/a10867b14bb761a232cd80139fbd4c0d33264240"
+    },
+    "name": "v0.2",
+    "node_id": "MDM6UmVmMTI5NjI3NDpyZWZzL3RhZ3MvdjAuMg==",
+    "tarball_url": "https:\/\/github.com\/octocat\/Hello-World\/tarball\/v0.2",
+    "zipball_url": "https:\/\/github.com\/octocat\/Hello-World\/zipball\/v0.2"
+  }
+]

--- a/Tests/OctoKitTests/RepositoryTests.swift
+++ b/Tests/OctoKitTests/RepositoryTests.swift
@@ -463,9 +463,9 @@ class RepositoryTests: XCTestCase {
         let task = Octokit(session: session).tags(owner: "octocat", name: "Hello-World") { response in
             switch response {
             case let .success(tags):
-                XCTAssertEqual(tags.count, 2)
-                XCTAssertEqual(tags[0].name, "v0.1")
-                XCTAssertEqual(tags[0].commit.sha, "c5b97d5ae6c19d5c5df71a34c7fbeeda2479ccbc")
+                XCTAssertEqual(tags.count, 31)
+                XCTAssertEqual(tags[0].name, "0.14.0")
+                XCTAssertEqual(tags[0].commit.sha, "cd108b387782d8509e64e298cf4800dc47fc40ae")
             case .failure:
                 XCTFail("should not get an error")
             }
@@ -482,8 +482,8 @@ class RepositoryTests: XCTestCase {
                                             jsonFile: "tags",
                                             statusCode: 200)
         let tags = try await Octokit(session: session).tags(owner: "octocat", name: "Hello-World")
-        XCTAssertEqual(tags.count, 2)
-        XCTAssertEqual(tags[0].name, "v0.1")
+        XCTAssertEqual(tags.count, 31)
+        XCTAssertEqual(tags[0].name, "0.14.0")
         XCTAssertTrue(session.wasCalled)
     }
     #endif
@@ -496,7 +496,7 @@ class RepositoryTests: XCTestCase {
         let task = Octokit(session: session).tagsPaginated(owner: "octocat", name: "Hello-World") { response in
             switch response {
             case let .success(paginated):
-                XCTAssertEqual(paginated.values.count, 2)
+                XCTAssertEqual(paginated.values.count, 31)
                 XCTAssertFalse(paginated.pageInfo.hasNextPage)
             case let .failure(error):
                 XCTAssertNil(error)
@@ -508,13 +508,13 @@ class RepositoryTests: XCTestCase {
 
     func testTagsParsing() {
         let tags = Helper.codableFromFile("tags", type: [RepositoryTag].self)
-        XCTAssertEqual(tags.count, 2)
-        XCTAssertEqual(tags[0].name, "v0.1")
-        XCTAssertEqual(tags[0].commit.sha, "c5b97d5ae6c19d5c5df71a34c7fbeeda2479ccbc")
-        XCTAssertEqual(tags[0].commit.url, "https://api.github.com/repos/octocat/Hello-World/commits/c5b97d5ae6c19d5c5df71a34c7fbeeda2479ccbc")
-        XCTAssertEqual(tags[0].zipballURL, "https://github.com/octocat/Hello-World/zipball/v0.1")
-        XCTAssertEqual(tags[0].tarballURL, "https://github.com/octocat/Hello-World/tarball/v0.1")
-        XCTAssertEqual(tags[0].nodeID, "MDM6UmVmMTI5NjI3NDpyZWZzL3RhZ3MvdjAuMQ==")
+        XCTAssertEqual(tags.count, 31)
+        XCTAssertEqual(tags[0].name, "0.14.0")
+        XCTAssertEqual(tags[0].commit.sha, "cd108b387782d8509e64e298cf4800dc47fc40ae")
+        XCTAssertEqual(tags[0].commit.url, "https://api.github.com/repos/nerdishbynature/octokit.swift/commits/cd108b387782d8509e64e298cf4800dc47fc40ae")
+        XCTAssertEqual(tags[0].zipballURL, "https://api.github.com/repos/nerdishbynature/octokit.swift/zipball/refs/tags/0.14.0")
+        XCTAssertEqual(tags[0].tarballURL, "https://api.github.com/repos/nerdishbynature/octokit.swift/tarball/refs/tags/0.14.0")
+        XCTAssertEqual(tags[0].nodeID, "MDM6UmVmMjkxNTI4OTI6cmVmcy90YWdzLzAuMTQuMA==")
     }
 
     func testRepositoriesPaginated() {

--- a/Tests/OctoKitTests/RepositoryTests.swift
+++ b/Tests/OctoKitTests/RepositoryTests.swift
@@ -455,6 +455,68 @@ class RepositoryTests: XCTestCase {
         XCTAssertEqual(submoduleContent.links.selfLink, "https://api.github.com/repos/muter-mutation-testing/muter/contents/homebrew-formulae?ref=master")
     }
 
+    func testListTags() {
+        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/Hello-World/tags?page=1&per_page=100",
+                                            expectedHTTPMethod: "GET",
+                                            jsonFile: "tags",
+                                            statusCode: 200)
+        let task = Octokit(session: session).tags(owner: "octocat", name: "Hello-World") { response in
+            switch response {
+            case let .success(tags):
+                XCTAssertEqual(tags.count, 2)
+                XCTAssertEqual(tags[0].name, "v0.1")
+                XCTAssertEqual(tags[0].commit.sha, "c5b97d5ae6c19d5c5df71a34c7fbeeda2479ccbc")
+            case .failure:
+                XCTFail("should not get an error")
+            }
+        }
+        XCTAssertNotNil(task)
+        XCTAssertTrue(session.wasCalled)
+    }
+
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func testListTagsAsync() async throws {
+        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/Hello-World/tags?page=1&per_page=100",
+                                            expectedHTTPMethod: "GET",
+                                            jsonFile: "tags",
+                                            statusCode: 200)
+        let tags = try await Octokit(session: session).tags(owner: "octocat", name: "Hello-World")
+        XCTAssertEqual(tags.count, 2)
+        XCTAssertEqual(tags[0].name, "v0.1")
+        XCTAssertTrue(session.wasCalled)
+    }
+    #endif
+
+    func testListTagsPaginated() {
+        let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/repos/octocat/Hello-World/tags?page=1&per_page=100",
+                                            expectedHTTPMethod: "GET",
+                                            jsonFile: "tags",
+                                            statusCode: 200)
+        let task = Octokit(session: session).tagsPaginated(owner: "octocat", name: "Hello-World") { response in
+            switch response {
+            case let .success(paginated):
+                XCTAssertEqual(paginated.values.count, 2)
+                XCTAssertFalse(paginated.pageInfo.hasNextPage)
+            case let .failure(error):
+                XCTAssertNil(error)
+            }
+        }
+        XCTAssertNotNil(task)
+        XCTAssertTrue(session.wasCalled)
+    }
+
+    func testTagsParsing() {
+        let tags = Helper.codableFromFile("tags", type: [RepositoryTag].self)
+        XCTAssertEqual(tags.count, 2)
+        XCTAssertEqual(tags[0].name, "v0.1")
+        XCTAssertEqual(tags[0].commit.sha, "c5b97d5ae6c19d5c5df71a34c7fbeeda2479ccbc")
+        XCTAssertEqual(tags[0].commit.url, "https://api.github.com/repos/octocat/Hello-World/commits/c5b97d5ae6c19d5c5df71a34c7fbeeda2479ccbc")
+        XCTAssertEqual(tags[0].zipballURL, "https://github.com/octocat/Hello-World/zipball/v0.1")
+        XCTAssertEqual(tags[0].tarballURL, "https://github.com/octocat/Hello-World/tarball/v0.1")
+        XCTAssertEqual(tags[0].nodeID, "MDM6UmVmMTI5NjI3NDpyZWZzL3RhZ3MvdjAuMQ==")
+    }
+
     func testRepositoriesPaginated() {
         let linkHeader = "<https://api.github.com/users/octocat/repos?page=2&per_page=100>; rel=\"next\""
         let session = OctoKitURLTestSession(expectedURL: "https://api.github.com/users/octocat/repos?page=1&per_page=100",

--- a/scripts/update-fixtures.sh
+++ b/scripts/update-fixtures.sh
@@ -33,6 +33,7 @@ run_cmd "user_mietzmithut.json"     user       get       nerdishbynature
 # Repository
 run_cmd "repo.json"                 repository get       nerdishbynature   octokit.swift
 run_cmd "user_repos.json"           repository get-list  nerdishbynature
+run_cmd "tags.json"                 repository get-tags  nerdishbynature   octokit.swift
 
 # Issue
 run_cmd "issue.json"                issue      get       nerdishbynature   octokit.swift   1


### PR DESCRIPTION
Implements GET /repos/{owner}/{repo}/tags via new `RepositoryTag` and `TagCommit` models, `tags()` and `tagsPaginated()` methods (callback + async), and a `listTags` router case. Adds `tags.json` fixture, 4 tests, a `repository get-tags` CLI subcommand, and a `run_cmd` entry in update-fixtures.sh. Also resolves merge conflict in Repository.swift, restoring missing GetTopics, GetContent, and GetTags subcommands.

Closes #153 