### PR TITLE
Drop SwiftFormat SPM dep so it stops leaking to consumers (#214)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,11 +20,11 @@ jobs:
   swiftformat:
     name: Linting
     runs-on: ubuntu-latest
-    container: swift:5.10-noble
+    container: ghcr.io/nicklockwood/swiftformat:0.52.8
     steps:
       - uses: actions/checkout@v2
       - name: Lint
-        run: swift package plugin --allow-writing-to-package-directory swiftformat --lint
+        run: swiftformat --lint .
   cli_build:
     name: Build CLI
     runs-on: ubuntu-latest

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "103d26dbf9e24efb90aca46eb3c94cf15e5847c3fc220990dd92f095ac2124cb",
+  "originHash" : "d459a6aeb6f190425bcc2e7e564bf289abfb0499f125a0900c9a2cab24849ee0",
   "pins" : [
     {
       "identity" : "requestkit",
@@ -8,15 +8,6 @@
       "state" : {
         "revision" : "9d45c9aacc1d46c87def44dd120d9c71dab3c788",
         "version" : "3.4.0"
-      }
-    },
-    {
-      "identity" : "swiftformat",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/nicklockwood/SwiftFormat",
-      "state" : {
-        "revision" : "4c8386a35e6a287387da041794b71b85d0858760",
-        "version" : "0.52.8"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/nerdishbynature/RequestKit.git", from: "3.4.0"),
-        .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.52.8")
+        .package(url: "https://github.com/nerdishbynature/RequestKit.git", from: "3.4.0")
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -440,3 +440,21 @@ func allIssues(owner: String, repo: String) async throws -> [Issue] {
 ```
 
 Paginated variants are available for: `myIssuesPaginated`, `issuesPaginated`, `pullRequestsPaginated`, `repositoriesPaginated`, `myNotificationsPaginated`, `listRepositoryNotificationsPaginated`, `listReleasesPaginated`, `labelsPaginated`.
+
+## Formatting
+
+OctoKit uses [SwiftFormat](https://github.com/nicklockwood/SwiftFormat) for code style. It is not declared as a Swift Package Manager dependency (to avoid propagating it to consumers), so install it locally before contributing:
+
+```sh
+brew install swiftformat
+# or
+mint install nicklockwood/SwiftFormat
+```
+
+Run the formatter from the repo root:
+
+```sh
+swiftformat .
+```
+
+CI enforces the same rules via `swiftformat --lint .`.


### PR DESCRIPTION
## Summary
- Removes `SwiftFormat` from `Package.swift` / `Package.resolved` so consumers of OctoKit no longer inherit it as a transitive SPM checkout.
- Switches the CI lint job to run `swiftformat --lint .` inside the official `ghcr.io/nicklockwood/swiftformat:0.52.8` container instead of the `swift package plugin swiftformat` invocation (which required the dep).
- Adds a short **Formatting** section to `README.md` telling contributors to install SwiftFormat via `brew` or `mint` and run `swiftformat .` locally.

Fixes #214.

## Why
SPM propagates every package-level dependency to consumers even when no target links against it, so downstream apps and CLI tools were paying the extra clone/build/disk cost for a formatter they never use. SwiftFormat was only ever referenced by the CI lint step — no target lists it as a dependency or plugin — so it can safely leave the manifest.

Swift 5.10 has no package traits, so an "optional" dep isn't available; running the tool out-of-band in CI is the cleanest fix.

## Test plan
- [x] `swift package resolve` — `Package.resolved` no longer pins `SwiftFormat`.
- [x] `swift build` — library builds clean.
- [x] `swift test --enable-test-discovery` — 208 tests pass.
- [x] `cd OctoKitCLI && swift build` — CLI builds clean.
- [x] `swiftformat --lint .` locally — 0/22 files require formatting.
- [x] CI green on the new lint job (`ghcr.io/nicklockwood/swiftformat:0.52.8`).
- [ ] Consumer sanity check: point a scratch SPM package at this branch and confirm no `SwiftFormat` checkout appears under `.build/checkouts`.